### PR TITLE
Scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## Features:  
 
+  - Easy to use API via Fluent API Presets (alert, propmt, confirm
+  - Easily add your own Presets.
   - Bootstrap model size configurable.  
   - Select cancel/quit key.  
   - Cascading.  
@@ -15,7 +17,7 @@
   - Blocking / Non blocking modal.  
   - Modal as a component, replace the content by supplying a custom component.  
   
-Click for the [Demo](http://shlomiassaf.github.io/angular2-modal/)  
+Click for the [Demo](http://shlomiassaf.github.io/angular2-modal/) Make sure to check the [code generator!](http://shlomiassaf.github.io/angular2-modal#/customizeModals)  
 If you're looking for a SystemJS demo, please see [this plunker](http://plnkr.co/edit/FnGdwU)  
 Click for the auto generated [Docs](http://shlomiassaf.github.io/angular2-modal/docs)   
 

--- a/angular2-modal.ts
+++ b/angular2-modal.ts
@@ -1,10 +1,1 @@
-/**
- * A Dummy file for the Webstrom IDE so it can access a directory as a package hence get intellisense.
- * Since only a directory in "node_modeules" is auto imported by WebStorm, this is a workaround.
- *
- * THIS FILE IS NEVER LOADED BY WEBPACK AND DOES NOT GO INTO THE BUNDLE
- *
- * See open issue: https://youtrack.jetbrains.com/issue/WEB-17533
- */
-
 export * from './src/components/angular2-modal/index';

--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <base href="/angular2-modal">
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Angular2 modal example.">
     <title>Angular 2 Modal - Bootstrap style.</title>
-    <base href="/angular2-modal/">
 </head>
 <body>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular2-modal",
   "description": "Angular2 Modal (dialog) window bootstrap style.",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/shlomiassaf/angular2-modal.git"

--- a/src/components/angular2-modal/angular2-modal.ts
+++ b/src/components/angular2-modal/angular2-modal.ts
@@ -3,7 +3,12 @@ export * from './models/ModalConfig';
 export * from './models/ModalDialogInstance';
 export * from './components/modalBackdrop';
 export * from './components/bootstrapModalContainer';
+export * from './components/modalFooter';
 export * from './providers/Modal';
+
+export * from './framework/FluentAssign';
+export * from './modals/MessageModal';
+export * from './presets';
 
 export * from './commonModals/yesNoModal';
 export * from './commonModals/okOnlyModal';

--- a/src/components/angular2-modal/commonModals/okOnlyModal.ts
+++ b/src/components/angular2-modal/commonModals/okOnlyModal.ts
@@ -4,7 +4,7 @@ import {ICustomModal, ICustomModalComponent} from '../models/ICustomModal';
 import {ModalDialogInstance} from '../models/ModalDialogInstance';
 
 /**
- * Data definition
+ * @deprecated
  */
 export class OKOnlyContent {
     constructor(
@@ -15,7 +15,7 @@ export class OKOnlyContent {
 }
 
 /**
- * A 2 state bootstrap modal window, representing 2 possible answer, true/false.
+ * @deprecated
  */
 @Component({
     selector: 'modal-content',
@@ -35,6 +35,8 @@ export class OKOnlyModal implements ICustomModalComponent {
     constructor(dialog: ModalDialogInstance, modelContentData: ICustomModal) {
         this.dialog = dialog;
         this.context = <OKOnlyContent>modelContentData;
+        console.warn('DEPRECATED: OKOnlyModal will not be available in next version of ' +
+            'angular2-modal, please move to the preset API.');
     }
 
     ok() {

--- a/src/components/angular2-modal/commonModals/yesNoModal.ts
+++ b/src/components/angular2-modal/commonModals/yesNoModal.ts
@@ -6,7 +6,7 @@ import {ICustomModal, ICustomModalComponent} from '../models/ICustomModal';
 import {ModalDialogInstance} from '../models/ModalDialogInstance';
 
 /**
- * Data definition
+ * @deprecated
  */
 export class YesNoModalContent {
     constructor(
@@ -19,7 +19,7 @@ export class YesNoModalContent {
 }
 
 /**
- * A 2 state bootstrap modal window, representing 2 possible answer, true/false.
+ * @deprecated
  */
 @Component({
     selector: 'modal-content',
@@ -41,6 +41,9 @@ export class YesNoModal implements ICustomModalComponent {
     constructor(dialog: ModalDialogInstance, modelContentData: ICustomModal) {
         this.dialog = dialog;
         this.context = <YesNoModalContent>modelContentData;
+        console.warn('DEPRECATED: YesNoModal will not be available in next version of ' +
+            'angular2-modal, please move to the preset API.')
+
     }
 
     ok($event: any) {

--- a/src/components/angular2-modal/components/modalFooter.ts
+++ b/src/components/angular2-modal/components/modalFooter.ts
@@ -1,0 +1,43 @@
+import { Component, Input, Output, EventEmitter } from 'angular2/core';
+import {ModalButtonConfig} from '../modals/MessageModal';
+
+export interface FooterButtonClickEvent {
+    btn: ModalButtonConfig;
+    $event: MouseEvent;
+}
+
+/**
+ * Represents the modal footer for storing buttons.
+ */
+@Component({
+    selector: 'modal-footer',
+    template:
+`<div [ngClass]="footerClass">
+    <button *ngFor="#btn of buttons;"
+            [ngClass]="btn.cssClass"
+            (click)="onClick(btn, $event)">{{btn.caption}}</button>
+</div>`
+})
+export class ModalFooter {
+    /**
+     * Class name used for the footer container.
+     */
+    @Input() public footerClass: string;
+
+    /**
+     * A collection of button configurations, each configuration is a button to display.
+     */
+    @Input() public buttons: ModalButtonConfig[];
+
+    /**
+     * Emitted when a button was clicked 
+     * @type {EventEmitter<FooterButtonClickEvent>}
+     */
+    @Output() public onButtonClick = new EventEmitter<FooterButtonClickEvent>();
+
+    constructor() {}
+
+    onClick(btn: any, $event: MouseEvent) {
+        this.onButtonClick.emit({btn, $event});
+    }
+}

--- a/src/components/angular2-modal/framework/FluentAssign.ts
+++ b/src/components/angular2-modal/framework/FluentAssign.ts
@@ -1,0 +1,163 @@
+
+const PRIVATE_PREFIX = '$$';
+const RESERVED_REGEX = /^(\$\$).*/;
+
+function validateMethodName(name: string) {
+    if (!name) {
+        throw new Error(`Illegal method name. Empty method name is not allowed`);
+    } else if (name in this) {
+        throw new Error(`A member name '${name}' already defined.`);
+    }
+}
+
+/**
+ * Returns a list of assigned property names (non private)
+ * @param subject
+ * @returns {string[]}
+ */
+function getAssignedPropertyNames(subject: any): string[] {
+    return Object.getOwnPropertyNames(subject)
+        .filter(name => RESERVED_REGEX.test(name))
+        .map(name => name.substr(2));
+}
+
+function privateKey(name: string): string {
+    return PRIVATE_PREFIX + name;
+}
+
+/**
+ * Create a function for setting a value for a property on a given object.
+ * @param obj The object to apply the key & setter on.
+ * @param propertyName The name of the property on the object
+ * @param writeOnce If true will allow writing once (default: false)
+ */
+export function setAssignMethod<T>(obj: T, propertyName: string, writeOnce: boolean = false): void {
+    validateMethodName.call(obj, propertyName);
+
+    Object.defineProperty(obj, propertyName, <any>{
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: function (value: any) {
+            let key = privateKey(propertyName);
+            if (writeOnce && this.hasOwnProperty(key)) {
+                throw new Error(`Overriding config property '${propertyName}' is not allowed.`);
+            }
+            this[key] = value;
+            return this;
+        }
+    });
+}
+
+
+/**
+ * Describes a fluent assign method.
+ * A function that gets a value and returns the instance it works on.
+ */
+export interface FluentAssignMethod<T, Z> {
+    //TODO: Setting 'this' instead of Z does not work, this=ConfigSetter here...
+    (value: T): Z;
+}
+
+
+export interface IFluentAssignFactory<Z> {
+    fluentAssign: Z;
+    setMethod(name: string, defaultValue?: any): IFluentAssignFactory<Z>;
+}
+
+/**
+ * Represent a fluent API factory wrapper for defining FluentAssign instances.
+ */
+export class FluentAssignFactory<T> {
+    private _fluentAssign: FluentAssign<T>;
+
+    constructor(fluentAssign?: FluentAssign<T>) {
+        this._fluentAssign =
+            fluentAssign instanceof FluentAssign ? fluentAssign : <any>new FluentAssign();
+    }
+
+    /**
+     * Create a setter method on the FluentAssign instance.
+     * @param name The name of the setter function.
+     * @param defaultValue If set (not undefined) set's the value on the instance immediately.
+     * @returns {FluentAssignFactory}
+     */
+    setMethod(name: string, defaultValue: any = undefined): FluentAssignFactory<T> {
+        setAssignMethod(this._fluentAssign, name);
+        if (defaultValue !== undefined) {
+            (<any>this._fluentAssign)[name](defaultValue);
+        }
+        return this;
+    }
+
+    /**
+     * The FluentAssign instance.
+     * @returns {FluentAssign<T>}
+     */
+    get fluentAssign(): FluentAssign<T> {
+        return this._fluentAssign;
+    }
+}
+
+/**
+ * Represent an object where every property is a function representing an assignment function.
+ * Calling each function with a value will assign the value to the object and return the object.
+ * Calling 'toJSON' returns an object with the same properties but this time representing the
+ * assigned values.
+ *
+ * This allows setting an object in a fluent API manner.
+ * Example:
+ let fluent = new FluentAssign<any>(undefined, ['some', 'went']);
+ fluent.some('thing').went('wrong').toJSON();
+ // { some: 'thing', went: 'wrong' }
+ */
+export class FluentAssign<T> {
+
+    /**
+     *
+     * @param defaultValues An object representing default values for the underlying object.
+     * @param initialSetters A list of initial setters for this FluentAssign.
+     */
+    constructor(defaultValues: T = undefined, initialSetters: string[] = undefined) {
+        if (defaultValues) {
+            Object.getOwnPropertyNames(defaultValues)
+                .forEach(name => (<any>this)[privateKey(name)] = (<any>defaultValues)[name]);
+        }
+
+        if (Array.isArray(initialSetters)) {
+            initialSetters.forEach(name => setAssignMethod(this, name));
+        }
+    }
+
+
+    /**
+     * Returns a FluentAssignFactory<FluentAssign<T>> ready to define a FluentAssign type.
+     * @param defaultValues An object representing default values for the instance.
+     * @param initialSetters A list of initial setters for the instance.
+     * @returns {FluentAssignFactory<T>}
+     */
+    static compose<T>(defaultValues: T = undefined,
+                      initialSetters: string[] = undefined): FluentAssignFactory<T> {
+
+        return <any>FluentAssign.composeWith<FluentAssign<T>>(
+            new FluentAssign<T>(defaultValues, initialSetters));
+    }
+
+    /**
+     * Returns a FluentAssignFactory<Z> where Z is an instance of FluentAssign<?> or a derived
+     * class of it.
+     * @param fluentAssign An instance of FluentAssign<?> or a derived class of FluentAssign<?>.
+     * @returns {any}
+     */
+    static composeWith<Z>(fluentAssign: Z): IFluentAssignFactory<Z> {
+        return <any>new FluentAssignFactory<any>(<any>fluentAssign);
+    }
+
+    toJSON(): T {
+        return getAssignedPropertyNames(this)
+            .reduce((obj: T, name: string) => {
+                (<any>obj)[name] = (<any>this)[privateKey(name)];
+                return obj;
+            }, <T><any>{});
+    }
+}

--- a/src/components/angular2-modal/framework/ModalInstanceStack.ts
+++ b/src/components/angular2-modal/framework/ModalInstanceStack.ts
@@ -1,0 +1,71 @@
+import {ModalDialogInstance} from '../models/ModalDialogInstance';
+import { DOM } from 'angular2/src/platform/dom/dom_adapter';
+
+/**
+ * A dumb stack implementation over an array.
+ */
+export class ModalInstanceStack {
+    private _stack: ModalDialogInstance[] = [];
+
+
+    push(mInstance: ModalDialogInstance): void {
+        let idx = this._stack.indexOf(mInstance);
+        if (idx === -1) this._stack.push(mInstance);
+
+        /* TODO: this is wrong for several reasons:
+         1) This is a direct DOM access we need to find another way or to separate it.
+         2) It not the place for it.
+         3) It doesn't care if its a modal inside an element or a wide open one.
+         If its inside an element we need to add the 'modal-open' to that element.
+         If its wide open we add to the body, we need to traverse the stack every time
+         know what's going on and do it.
+         */
+        if (this._stack.length === 1) {
+            DOM.addClass(DOM.query('body'), 'modal-open');
+        }
+    }
+
+    /**
+     * Push a ModalDialogInstance into the stack and manage it so when it's done
+     * it will automatically kick itself out of the stack.
+     * @param mInstance
+     */
+    pushManaged(mInstance: ModalDialogInstance): void {
+        this.push(mInstance);
+        mInstance.result
+            .then(() => this.remove(mInstance))
+            .catch(() => this.remove(mInstance));
+        // we don't "pop" because we can't know for sure that our instance is the last.
+        // In a user event world it will be the last, but since modals can close programmatically
+        // we can't tell.
+    }
+
+    pop(): void {
+        this._stack.pop();
+    }
+
+    /**
+     * Remove a ModalDialogInstance from the stack.
+     * @param mInstance
+     */
+    remove(mInstance: ModalDialogInstance): void {
+        let idx = this._stack.indexOf(mInstance);
+        if (idx > -1) this._stack.splice(idx, 1);
+        if (this._stack.length === 0) {
+            DOM.removeClass(DOM.query('body'), 'modal-open');
+        }
+    }
+
+
+    index(index: number): ModalDialogInstance {
+        return this._stack[index];
+    }
+
+    indexOf(mInstance: ModalDialogInstance): number {
+        return this._stack.indexOf(mInstance);
+    }
+
+    get length(): number {
+        return this._stack.length;
+    }
+}

--- a/src/components/angular2-modal/framework/ModalInstanceStack.ts
+++ b/src/components/angular2-modal/framework/ModalInstanceStack.ts
@@ -20,7 +20,7 @@ export class ModalInstanceStack {
          If its wide open we add to the body, we need to traverse the stack every time
          know what's going on and do it.
          */
-        if (this._stack.length === 1) {
+        if (DOM && this._stack.length === 1) {
             DOM.addClass(DOM.query('body'), 'modal-open');
         }
     }
@@ -51,7 +51,7 @@ export class ModalInstanceStack {
     remove(mInstance: ModalDialogInstance): void {
         let idx = this._stack.indexOf(mInstance);
         if (idx > -1) this._stack.splice(idx, 1);
-        if (this._stack.length === 0) {
+        if (DOM && this._stack.length === 0) {
             DOM.removeClass(DOM.query('body'), 'modal-open');
         }
     }

--- a/src/components/angular2-modal/framework/Utils.ts
+++ b/src/components/angular2-modal/framework/Utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Simple object extend
+ * @param m1
+ * @param m2
+ * @returns {{}}
+ */
+export function extend<T>(m1: any, m2: any): T {
+    var m: T = <T>{};
+    for (var attr in m1) {
+        if (m1.hasOwnProperty(attr)) {
+            (<any>m)[attr] = (<any>m1)[attr];
+        }
+    }
+
+    for (var attr in m2) {
+        if (m2.hasOwnProperty(attr)) {
+            (<any>m)[attr] = (<any>m2)[attr];
+        }
+    }
+
+    return m;
+}
+
+/**
+ * Simple, not optimized, array union of unique values.
+ * @param arr1
+ * @param arr2
+ * @returns {T[]|any[]|any[][]|any[]}
+ */
+export function arrayUnion<T>(arr1: any[], arr2: any[]): T[] {
+    return arr1
+        .concat(arr2.filter(v => arr1.indexOf(v) === -1));
+
+}

--- a/src/components/angular2-modal/modals/MessageModal.ts
+++ b/src/components/angular2-modal/modals/MessageModal.ts
@@ -1,0 +1,104 @@
+import {Component} from 'angular2/core';
+
+import {ICustomModal, ICustomModalComponent} from '../models/ICustomModal';
+import {ModalDialogInstance} from '../models/ModalDialogInstance';
+import {ModalFooter, FooterButtonClickEvent} from '../components/modalFooter';
+
+/**
+ * Interface for button definition
+ */
+export interface ModalButtonConfig {
+    cssClass: string;
+    caption: string;
+    onClick: (modalComponent: any, $event?: MouseEvent) => void;
+}
+
+/**
+ * Data definition
+ */
+export class MessageModalContext implements ICustomModal {
+    /**
+     * A Class for the header (title) container.
+     * Default: modal-header
+     */
+    headerClass: string;
+
+    /**
+     * Caption for the title, enclosed in a H3 container.
+     */
+    title: string;
+
+    /**
+     * HTML for the title, if set overrides title property.
+     * The HTML is wrapped in a DIV element, inside the header container.
+     * Example:
+     <div class="modal-header">
+        <div> HTML CONTENT INSERTED HERE </div>
+     </div>
+     * Note: HTML is not compiled.
+     */
+    titleHtml: string;
+
+    /**
+     * The body of the message.
+     * Can be either text or HTML.
+     * Note: HTML is not compiled.
+     */
+    body: string;
+    /**
+     * A Class for the body container.
+     * Default: modal-body
+     */
+    bodyClass: string;
+
+    /**
+     * A Class for the footer container.
+     * Default: modal-footer
+     */
+    footerClass: string;
+
+    buttons: ModalButtonConfig[];
+}
+
+/**
+ * A Component representing a generic bootstrap modal content element.
+ * 
+ * By configuring a MessageModalContext instance you can:
+ * 
+ *  Header: 
+ *      - Set header container class (default: modal-header)
+ *      - Set title text (enclosed in H3 element)
+ *      - Set title html (overrides text)
+ *      
+ *  Body:
+ *      - Set body container class.  (default: modal-body)
+ *      - Set body container HTML.
+ *      
+ *  Footer:
+ *      - Set footer class.  (default: modal-footer)
+ *      - Set button configuration (from 0 to n)
+ */
+@Component({
+    selector: 'modal-content',
+    directives: [ModalFooter],
+    template:
+    `<div [ngClass]="context.headerClass" [ngSwitch]="titleHtml">
+        <div *ngSwitchWhen="1" [innerHtml]="context.titleHtml"></div>
+        <h3 *ngSwitchDefault class="modal-title">{{context.title}}</h3>
+    </div>
+    <div [ngClass]="context.bodyClass" [innerHtml]="context.body"></div>
+    <modal-footer [footerClass]="context.footerClass" 
+                  [buttons]="context.buttons"
+                  (onButtonClick)="onFooterButtonClick($event)"></modal-footer>`
+})
+export class MessageModal implements ICustomModalComponent {
+    constructor(public dialog: ModalDialogInstance, public context: MessageModalContext) {}
+
+    onFooterButtonClick($event: FooterButtonClickEvent) {
+        $event.btn.onClick(this, $event.$event);
+    }
+
+    get titleHtml(): number {
+        return this.context.titleHtml ? 1 : 0;
+    }
+}

--- a/src/components/angular2-modal/models/ModalConfig.ts
+++ b/src/components/angular2-modal/models/ModalConfig.ts
@@ -1,13 +1,37 @@
 import {Injectable} from 'angular2/core';
 let _defaultConfig: ModalConfig;
 
+export interface IModalConfig {
+    /**
+     * Size of the modal.
+     * 'lg' or 'sm' only.
+     * NOTE: No validation.
+     * Default to 'lg'
+     */
+    size: string;
+
+    /**
+     * Describes if the modal is blocking modal.
+     * A Blocking modal is not closable by clicking outside of the modal window.
+     * Defaults to false.
+     */
+    isBlocking: boolean;
+
+    /**
+     * Keyboard value/s that close the modal.
+     * Accepts either a single numeric value or an array of numeric values.
+     * A modal closed by a keyboard stroke will result in a 'reject' notification from the promise.
+     * Defaults to 27, set `null` implicitly to disable.
+     */
+    keyboard: Array<number> | number;
+}
 
 /**
  * A configuration definition object.
  * Instruction for how to show a modal.
  */
 @Injectable()
-export class ModalConfig {
+export class ModalConfig implements IModalConfig {
     /**
      * Size of the modal.
      * 'lg' or 'sm' only.

--- a/src/components/angular2-modal/presets.ts
+++ b/src/components/angular2-modal/presets.ts
@@ -1,0 +1,4 @@
+export * from './presets/base/ModalAwarePreset';
+export * from './presets/base/MessageModalPreset';
+export {OneButtonPreset, OneButtonPresetData} from './presets/OneButtonPreset'
+export {TwoButtonPreset, TwoButtonPresetData} from './presets/TwoButtonPreset'

--- a/src/components/angular2-modal/presets/OneButtonPreset.ts
+++ b/src/components/angular2-modal/presets/OneButtonPreset.ts
@@ -1,0 +1,57 @@
+import { Injector, provide , ResolvedBinding} from 'angular2/core';
+import {FluentAssignMethod} from '../framework/FluentAssign';
+import {Modal} from '../providers/Modal';
+import {MessageModalContext, MessageModal} from '../modals/MessageModal';
+import {MessageModalPreset, MessageModalPresetData} from './base/MessageModalPreset';
+import {extend} from '../framework/Utils';
+
+
+function createBindings(config: OneButtonPresetData): ResolvedBinding[] {
+    config.buttons = [
+        {
+            cssClass: config.okBtnClass,
+            caption: config.okBtn,
+            onClick: (modalComponent: MessageModal, $event?: MouseEvent) =>
+                modalComponent.dialog.close(true)
+        }
+    ];
+
+    return Injector.resolve([
+        provide(MessageModalContext, {useValue: config})
+    ]);
+}
+
+export interface OneButtonPresetData extends MessageModalPresetData {
+    /** 
+     * Caption for the OK button.
+     * Default: OK
+     */
+    okBtn: string;
+
+    /**
+     * A Class for the OK button.
+     * Default: btn btn-primary
+     */
+    okBtnClass: string;
+}
+
+/**
+ * A Preset for a classic 1 button modal window.
+ */
+export class OneButtonPreset extends MessageModalPreset<OneButtonPresetData> {
+    constructor(modal: Modal, defaultValues: OneButtonPresetData = undefined) {
+        super(extend<any>( {
+            modal: modal,
+            bindings: createBindings,
+            okBtn: 'OK',
+            okBtnClass: 'btn btn-primary'
+        }, defaultValues || {}), [
+            'okBtn',
+            'okBtnClass'
+        ]);
+    }
+
+    okBtn: FluentAssignMethod<string, this>;
+    okBtnClass: FluentAssignMethod<string, this>;
+}
+

--- a/src/components/angular2-modal/presets/TwoButtonPreset.ts
+++ b/src/components/angular2-modal/presets/TwoButtonPreset.ts
@@ -1,0 +1,70 @@
+import { Injector, provide , ResolvedBinding} from 'angular2/core';
+import {FluentAssignMethod} from '../framework/FluentAssign';
+import {extend} from '../framework/Utils';
+import {Modal} from '../providers/Modal';
+import {MessageModalContext, MessageModal} from '../modals/MessageModal';
+import {MessageModalPreset} from './base/MessageModalPreset';
+import {OneButtonPresetData} from './OneButtonPreset';
+
+
+function createBindings(config: TwoButtonPresetData): ResolvedBinding[] {
+    config.buttons = [
+        {
+            cssClass: config.okBtnClass,
+            caption: config.okBtn,
+            onClick: (modalComponent: MessageModal, $event: MouseEvent) =>
+                modalComponent.dialog.close(true)
+        },
+        {
+            cssClass: config.cancelBtnClass,
+            caption: config.cancelBtn,
+            onClick: (modalComponent: MessageModal, $event: MouseEvent) =>
+                modalComponent.dialog.dismiss()
+        }
+    ];
+
+    return Injector.resolve([
+        provide(MessageModalContext, {useValue: config})
+    ]);
+}
+
+export interface TwoButtonPresetData extends OneButtonPresetData {
+    /** 
+     * Caption for the Cancel button.
+     * Default: Cancel
+     */
+    cancelBtn: string;
+
+    /**
+     * A Class for the Cancel button.
+     * Default: btn btn-default
+     */
+    cancelBtnClass: string;
+}
+
+/**
+ * A Preset for a classic 2 button modal window.
+ */
+export class TwoButtonPreset extends MessageModalPreset<TwoButtonPresetData> {
+    constructor(modal: Modal, defaultValues: TwoButtonPresetData = undefined) {
+        super(extend<any>( {
+            modal: modal,
+            bindings: createBindings,
+            okBtn: 'OK',
+            okBtnClass: 'btn btn-primary',
+            cancelBtn: 'Cancel',
+            cancelBtnClass: 'btn btn-default'
+        }, defaultValues || {}), [
+            'okBtn',
+            'okBtnClass',
+            'cancelBtn',
+            'cancelBtnClass'
+        ]);
+    }
+
+    okBtn: FluentAssignMethod<string, this>;
+    okBtnClass: FluentAssignMethod<string, this>;
+    cancelBtn: FluentAssignMethod<string, this>;
+    cancelBtnClass: FluentAssignMethod<string, this>;
+}
+

--- a/src/components/angular2-modal/presets/base/MessageModalPreset.ts
+++ b/src/components/angular2-modal/presets/base/MessageModalPreset.ts
@@ -1,0 +1,44 @@
+import {FluentAssignMethod} from '../../framework/FluentAssign';
+import {ModalAwarePreset, ModalAwarePresetData} from './ModalAwarePreset';
+import {MessageModal, MessageModalContext} from '../../modals/MessageModal';
+import {extend, arrayUnion} from '../../framework/Utils';
+
+
+const DEFAULT_CONFIG_VALUES = {
+    component: MessageModal,
+    headerClass: 'modal-header',
+    bodyClass: 'modal-body',
+    footerClass: 'modal-footer'
+};
+
+const DEFAULT_INITIAL_SETTERS = [
+    'headerClass',
+    'title',
+    'titleHtml',
+    'body',
+    'bodyClass',
+    'footerClass'
+];
+
+export interface MessageModalPresetData extends MessageModalContext, ModalAwarePresetData {}
+
+/**
+ * A Preset representing the configuration needed to open MessageModal.
+ * This is an abstract implementation with no concrete behaviour.
+ * Use derived implementation.
+ */
+export abstract class MessageModalPreset<T extends MessageModalPresetData>
+                                                                    extends ModalAwarePreset<T> {
+
+    constructor(defaultValues: T = undefined, initialSetters: string[] = undefined) {
+        super(extend<any>(DEFAULT_CONFIG_VALUES, defaultValues || {}),
+            arrayUnion<string>(DEFAULT_INITIAL_SETTERS, initialSetters || []));
+    }
+
+    headerClass: FluentAssignMethod<string, this>;
+    title: FluentAssignMethod<string, this>;
+    titleHtml: FluentAssignMethod<string, this>;
+    body: FluentAssignMethod<string, this>;
+    bodyClass: FluentAssignMethod<string, this>;
+    footerClass: FluentAssignMethod<string, this>;
+}

--- a/src/components/angular2-modal/presets/base/ModalAwarePreset.ts
+++ b/src/components/angular2-modal/presets/base/ModalAwarePreset.ts
@@ -1,0 +1,71 @@
+import { ResolvedProvider, ElementRef } from 'angular2/core';
+import {Modal} from '../../providers/Modal';
+import {IModalConfig, ModalConfig} from '../../models/ModalConfig';
+import {FluentAssign, FluentAssignMethod, setAssignMethod} from './../../framework/FluentAssign';
+import {ModalDialogInstance} from '../../models/ModalDialogInstance';
+
+export interface ModalAwarePresetData extends IModalConfig {
+    component: any;
+    modal: Modal;
+    bindings: <T>(config: T) => ResolvedProvider[];
+}
+
+
+/**
+ * A Preset that knows about the modal service, and so can open a modal window on demand.
+ * Use the fluent API to configure the preset and then invoke the 'open' method to open a modal
+ * based on the preset.
+ * ModalAwarePreset occupy the following properties:
+ * - ModalConfig (size, isBlocking, keyboard): You can set them, if not they will get the 
+ * default values defined in the Modal service.  
+ * - component, modal, bindings: Preset values needed to fire up the modal.
+ * - open: A Method used to open the modal window.
+ */
+export class ModalAwarePreset<T extends ModalAwarePresetData> extends FluentAssign<T> {
+    constructor(defaultValues: T = undefined, initialSetters: string[] = undefined) {
+        super(defaultValues, initialSetters);
+        // this is not needed as we get them via defaults.
+        // but it "protects" overwrites since we set writeOnce=true.
+        setAssignMethod(this, 'modal', true);
+        setAssignMethod(this, 'component', true);
+        setAssignMethod(this, 'bindings', true);
+
+        setAssignMethod(this, 'size');
+        setAssignMethod(this, 'isBlocking');
+        setAssignMethod(this, 'keyboard');
+    }
+
+    size: FluentAssignMethod<string, this>;
+    isBlocking: FluentAssignMethod<boolean, this>;
+    keyboard: FluentAssignMethod<Array<number> | number, this>;
+
+    /**
+     * Open a modal window based on the configuration of this config instance.
+     * @param inside If set opens the modal inside the supplied elements ref at the specified anchor
+     * @returns Promise<ModalDialogInstance>
+     */
+    open(inside?: {elementRef: ElementRef, anchorName: string}): Promise<ModalDialogInstance> {
+        let config: T = this.toJSON();
+
+        if (! (config.modal instanceof Modal) ) {
+            return <any>Promise.reject(new Error('Configuration Error: modal service not set.'));
+        }
+
+        if (typeof config.bindings !== 'function') {
+            return <any>Promise.reject(new Error('Configuration Error: bindings not set.'));
+        }
+
+        if (inside) {
+            // TODO: Validate inside?
+            return config.modal.openInside(config.component,
+                inside.elementRef,
+                inside.anchorName,
+                config.bindings(config),
+                new ModalConfig(config.size, config.isBlocking, config.keyboard));
+        } else {
+            return config.modal.open(config.component,
+                config.bindings(config),
+                new ModalConfig(config.size, config.isBlocking, config.keyboard));
+        }
+    }
+}

--- a/src/components/angular2-modal/providers/Modal.ts
+++ b/src/components/angular2-modal/providers/Modal.ts
@@ -9,82 +9,16 @@ import {
     Optional,
     ApplicationRef
 } from 'angular2/core';
+
+import {ModalInstanceStack} from '../framework/ModalInstanceStack';
 import {ModalConfig} from '../models/ModalConfig';
 import {ModalDialogInstance} from '../models/ModalDialogInstance';
 import {ModalBackdrop} from '../components/modalBackdrop';
 import {BootstrapModalContainer} from '../components/bootstrapModalContainer';
-import { DOM } from 'angular2/src/platform/dom/dom_adapter';
+import {OneButtonPreset, TwoButtonPreset} from '../presets';
 
-
-/**
- * A dumb stack implementation over an array.
- */
-class ModalInstanceStack {
-    private _stack: ModalDialogInstance[] = [];
-
-
-    push(mInstance: ModalDialogInstance): void {
-        let idx = this._stack.indexOf(mInstance);
-        if (idx === -1) this._stack.push(mInstance);
-
-        /* TODO: this is wrong for several reasons:
-            1) This is a direct DOM access we need to find another way or to separate it.
-            2) It not the place for it.
-            3) It doesn't care if its a modal inside an element or a wide open one.
-               If its inside an element we need to add the 'modal-open' to that element.
-               If its wide open we add to the body, we need to traverse the stack every time
-               know what's going on and do it.
-         */
-        if (this._stack.length === 1) {
-            DOM.addClass(DOM.query('body'), 'modal-open');
-        }
-    }
-
-    /**
-     * Push a ModalDialogInstance into the stack and manage it so when it's done
-     * it will automatically kick itself out of the stack.
-     * @param mInstance
-     */
-    pushManaged(mInstance: ModalDialogInstance): void {
-        this.push(mInstance);
-        mInstance.result
-            .then(() => this.remove(mInstance))
-            .catch(() => this.remove(mInstance));
-        // we don't "pop" because we can't know for sure that our instance is the last.
-        // In a user event world it will be the last, but since modals can close programmatically
-        // we can't tell.
-    }
-
-    pop(): void {
-        this._stack.pop();
-    }
-
-    /**
-     * Remove a ModalDialogInstance from the stack.
-     * @param mInstance
-     */
-    remove(mInstance: ModalDialogInstance): void {
-        let idx = this._stack.indexOf(mInstance);
-        if (idx > -1) this._stack.splice(idx, 1);
-        if (this._stack.length === 0) {
-            DOM.removeClass(DOM.query('body'), 'modal-open');
-        }
-    }
-
-
-    index(index: number): ModalDialogInstance {
-        return this._stack[index];
-    }
-
-    indexOf(mInstance: ModalDialogInstance): number {
-        return this._stack.indexOf(mInstance);
-    }
-
-    get length(): number {
-        return this._stack.length;
-    }
-}
 const _stack = new ModalInstanceStack();
+
 
 @Injectable()
 export class Modal {
@@ -103,6 +37,18 @@ export class Modal {
             value: (defaultConfig) ? ModalConfig.makeValid(defaultConfig) : new ModalConfig(),
             writable: false
         });
+    }
+
+    alert(): OneButtonPreset {
+        return new OneButtonPreset(this, <any>{ isBlocking: false });
+    }
+
+    prompt(): OneButtonPreset {
+        return new OneButtonPreset(this, <any>{ isBlocking: true, keyboard: null });
+    }
+
+    confirm(): TwoButtonPreset {
+        return new TwoButtonPreset(this, <any>{ isBlocking: true, keyboard: null });
     }
 
     /**

--- a/src/demo/app/app.ts
+++ b/src/demo/app/app.ts
@@ -1,10 +1,9 @@
 import {Component} from 'angular2/core';
-import {RouteConfig, Router, ROUTER_DIRECTIVES} from 'angular2/router';
-import {Http} from 'angular2/http';
+import {RouteConfig, ROUTER_DIRECTIVES} from 'angular2/router';
 import {FORM_PROVIDERS} from 'angular2/common';
 
 import {DemoPage} from './demoPage/demoPage';
-
+import {CustomizeWizard} from './customizeWizard/customizeWizard';
 /*
  * App Component
  * Top Level Component
@@ -28,7 +27,8 @@ import {DemoPage} from './demoPage/demoPage';
   `
 })
 @RouteConfig([
-    { path: '/', component: DemoPage, name: 'Demo' }
+    { path: '/', component: DemoPage, name: 'Demo' },
+    { path: '/customizeModals', component: CustomizeWizard, name: 'CustomizeModals' }
 ])
 export class App {
     constructor() {}

--- a/src/demo/app/customizeWizard/customizeWizard.tpl.html
+++ b/src/demo/app/customizeWizard/customizeWizard.tpl.html
@@ -1,0 +1,172 @@
+<div class="container-fluid">
+    <h1>Customize A modal window</h1>
+    <p class="lead">Configure a modal, see the code and view the output!</p>
+    <hr>
+    <div class="col-md-6">
+        <div class="col-xs-6">
+            <h3>Configuration:</h3>
+        </div>
+        <div class="col-xs-6 col-md-4">
+            <button class="btn btn-success pull-right" (click)="createModal()">Open Modal</button>
+        </div>
+        <div class="col-xs-12">
+            <form class="form-horizontal" #form="ngForm" (ngSubmit)="logForm(form.value)">
+                <fieldset>
+
+                    <!-- Select Basic -->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="modalType">Type</label>
+                        <div class="col-md-6">
+                            <select id="modalType" name="modalType" class="form-control"
+                                    [(ngModel)]="type">
+                                <option value="alert">Alert</option>
+                                <option value="prompt">Prompt</option>
+                                <option value="confirm">Confirm</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="modalSize">Modal Size</label>
+                        <div class="col-md-6">
+                            <select id="modalSize" name="modalSize" class="form-control"
+                                    [(ngModel)]="preset.size">
+                                <option value="sm">Small</option>
+                                <option value="lg">Large</option>
+                            </select>
+                        </div>
+                    </div>
+
+
+                    <!-- Multiple Checkboxes (inline) -->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="checkbox">Blocking?</label>
+                        <div class="col-md-6">
+                            <input type="checkbox" name="checkbox" id="checkbox"
+                                   [(ngModel)]="preset.isBlocking">
+                        </div>
+                    </div>
+
+                    <!-- Text input-->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="closeKeys">Close Key</label>
+                        <div class="col-md-6">
+                            <input id="closeKeys" name="closeKeys" type="number" placeholder="27"
+                                   class="form-control input-md" [(ngModel)]="preset.keyboard">
+                            <span class="help-block">Key code for closing the window (e.g: 27 for ESC)</span>
+                        </div>
+                    </div>
+
+                    <!-- Text input-->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="headerClass">Header Class</label>
+                        <div class="col-md-6">
+                            <input id="headerClass" name="headerClass" type="text"
+                                   placeholder="modal-header" class="form-control input-md"
+                                   [(ngModel)]="preset.headerClass">
+                            <span class="help-block"> A Class for the header (title) container.  Default: modal-header</span>
+                        </div>
+                    </div>
+
+                    <!-- Text input-->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="title">Title</label>
+                        <div class="col-md-6">
+                            <input id="title" name="title" type="text" placeholder="This is a title"
+                                   class="form-control input-md" [(ngModel)]="preset.title">
+                            <span class="help-block">Caption for the title, enclosed in a H3 container.</span>
+                        </div>
+                    </div>
+
+                    <!-- Textarea -->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="titleHtml">Title (HTML)</label>
+                        <div class="col-md-6">
+                        <textarea class="form-control" id="titleHtml" name="titleHtml"
+                                  [(ngModel)]="preset.titleHtml"></textarea>
+                        </div>
+                        <p class="help-block">An HTML (not compiled) body, if set Title is ignored.</p>
+                    </div>
+
+                    <!-- Textarea -->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="body">Body</label>
+                        <div class="col-md-4">
+                        <textarea class="form-control" id="body" name="body"
+                                  [(ngModel)]="preset.body"></textarea>
+                        </div>
+                    </div>
+
+                    <!-- Text input-->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="bodyClass">Body Class</label>
+                        <div class="col-md-6">
+                            <input id="bodyClass" name="bodyClass" type="text" placeholder="modal-body"
+                                   class="form-control input-md" [(ngModel)]="preset.bodyClass">
+                            <span class="help-block">A Class for the body container. Default: modal-body</span>
+                        </div>
+                    </div>
+
+                    <!-- Text input-->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="footerClass">Footer Class</label>
+                        <div class="col-md-6">
+                            <input id="footerClass" name="footerClass" type="text"
+                                   placeholder="modal-footer" class="form-control input-md"
+                                   [(ngModel)]="preset.footerClass">
+                            <span class="help-block">A Class for the footer container. Default: modal-footer</span>
+                        </div>
+                    </div>
+
+                    <!-- Text input-->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="okBtn">OK Button Text</label>
+                        <div class="col-md-6">
+                            <input id="okBtn" name="okBtn" type="text" placeholder="OK"
+                                   class="form-control input-md"
+                                   [(ngModel)]="preset.okBtn">
+                            <span class="help-block">Caption for the OK button. Default: OK</span>
+                        </div>
+                    </div>
+
+                    <!-- Text input-->
+                    <div class="form-group">
+                        <label class="col-md-4 control-label" for="okBtnClass">OK Button Class</label>
+                        <div class="col-md-6">
+                            <input id="okBtnClass" name="okBtnClass" type="text"
+                                   placeholder="btn btn-primary" class="form-control input-md"
+                                   [(ngModel)]="preset.okBtnClass">
+                            <span class="help-block">A Class for the OK button. Default: btn btn-primary</span>
+                        </div>
+                    </div>
+
+                    <!-- Text input-->
+                    <div class="form-group" *ngIf="type === 'confirm'">
+                        <label class="col-md-4 control-label" for="cancelBtn">Cancel Button Text</label>
+                        <div class="col-md-6">
+                            <input id="cancelBtn" name="cancelBtn" type="text" placeholder="Cancel"
+                                   class="form-control input-md" [(ngModel)]="preset.cancelBtn">
+                            <span class="help-block">Caption for the Cancel button. Default: Cancel</span>
+                        </div>
+                    </div>
+
+                    <!-- Text input-->
+                    <div class="form-group" *ngIf="type === 'confirm'">
+                        <label class="col-md-4 control-label" for="cancelBtnClass">Cancel Button Class</label>
+                        <div class="col-md-6">
+                            <input id="cancelBtnClass" name="cancelBtnClass" type="text"
+                                   placeholder="btn btn-default" class="form-control input-md"
+                                   [(ngModel)]="preset.cancelBtnClass">
+                            <span class="help-block">A Class for the Cancel button. Default: btn btn-default</span>
+                        </div>
+                    </div>
+
+                </fieldset>
+            </form>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <h3>Code:</h3>
+        <pre>{{code}}</pre>
+    </div>
+</div>

--- a/src/demo/app/customizeWizard/customizeWizard.ts
+++ b/src/demo/app/customizeWizard/customizeWizard.ts
@@ -1,0 +1,56 @@
+import { Component } from 'angular2/core';
+import {Modal, TwoButtonPresetData, TwoButtonPreset} from 'angular2-modal';
+let html = require('./customizeWizard.tpl.html');
+
+
+@Component({
+    selector: 'customize-wizard',
+    directives: [],
+    providers: [Modal],
+    template: html
+})
+export class CustomizeWizard {
+    type: 'alert' | 'prompt' | 'confirm' = 'alert';
+    public preset: TwoButtonPresetData = <any>{
+        size: 'lg',
+        isBlocking: true,
+        keyboard: 27,
+        headerClass: '',
+        title: 'Hello World',
+        titleHtml: '',
+        body: 'A Customized Modal',
+        bodyClass: '',
+        footerClass: '',
+        okBtn: '',
+        okBtnClass: '',
+    };
+
+    constructor(private modal: Modal) {}
+
+    createModal() {
+        let p = this.preset;
+
+        let fluent: TwoButtonPreset = <any>this.modal[this.type]();
+        for (let key in p) {
+            let value = p[key];
+            if (value === null || value === '') continue;
+            fluent[key](value);
+        }
+
+        fluent.open();
+    }
+
+    get code(): string {
+        let p = this.preset,
+            code = `modal.${this.type}()\n`;
+
+        for (let key in p) {
+            let value = p[key];
+            if (value === null || value === '') continue;
+            code += `    .${key}(${typeof value === 'string' ? `'${value}'` : value})\n`;
+    }
+
+        code += '    .open();';
+        return code;
+    }
+}

--- a/src/demo/app/demoPage/demoPage.tpl.html
+++ b/src/demo/app/demoPage/demoPage.tpl.html
@@ -4,14 +4,11 @@
     <br>
     <div class="row">
         <div class="col-xs-12">
-            <button class="btn btn-default" (click)="openDialog('large')">Large Modal</button>
-            <button class="btn btn-default" (click)="openDialog('small')">Small Modal</button>
-            <button class="btn btn-default" (click)="openDialog('yesno')">Custom Buttons Modal</button>
-            <button class="btn btn-default" (click)="openDialog('key')">Keyboard quit</button>
-            <button class="btn btn-default" (click)="openDialog('blocking')">Blocking Modal</button>
-            <button class="btn btn-default" (click)="openDialog('blocking'); openDialog('small'); openDialog('large')">Cascading</button>
-            <button class="btn btn-default" (click)="openDialog('inElement')">In Element Modal</button>
-            <button class="btn btn-default" (click)="openDialog('customWindow')">Custom Window</button>
+            <button *ngFor="#btn of buttons;"
+                    class="btn btn-default"
+                    (click)="open(btn)">{{btn.text}}</button>
+            <button class="btn btn-default" (click)="openCustomModal()">Custom Modal</button>
+            <a [routerLink]="['CustomizeModals']">Or use the modal code Generator!</a>
         </div>
     </div>
     <br><br><br><br>

--- a/src/demo/app/demoPage/demoPage.ts
+++ b/src/demo/app/demoPage/demoPage.ts
@@ -1,74 +1,77 @@
-import { Component, provide, ElementRef, Injector, Renderer} from 'angular2/core';
-
-import {ModalDialogInstance, ModalConfig, Modal, ICustomModal,
-    YesNoModalContent, YesNoModal} from 'angular2-modal';
-
+import { Component, provide, ElementRef, Injector} from 'angular2/core';
+import {RouterLink} from 'angular2/router';
+import {ModalConfig, Modal, ICustomModal, ModalDialogInstance} from 'angular2-modal';
 import {AdditionCalculateWindowData, AdditionCalculateWindow} from '../customModalDemo/customModal';
-
 import {SampleElement} from '../sampleElement/sampleElement';
+import * as presets from './presets';
+
+const BUTTONS = [
+    {
+        text: 'Alert',
+        preset: presets.alert
+    },
+    {
+        text: 'Prompt',
+        preset: presets.prompt
+    },
+    {
+        text: 'Confirm',
+        preset: presets.confirm
+    },
+    {
+        text: 'Cascading',
+        preset: presets.cascading
+    },
+    {
+        text: 'In Element',
+        preset: presets.inElement
+    }
+];
 
 @Component({
     selector: 'demo-page',
-    directives: [SampleElement],
+    directives: [SampleElement, RouterLink],
     providers: [Modal],
     styles: [ require('./demoPage.css') ],
     template: require('./demoPage.tpl.html')
 })
-
 export class DemoPage {
     public mySampleElement: ElementRef;
     public lastModalResult: string;
+    public buttons = BUTTONS;
+    constructor(private modal: Modal) {}
 
-    constructor(private modal: Modal, private elementRef: ElementRef,
-                private injector: Injector, private _renderer: Renderer) {}
-
-    /* tslint:disable */
-    // We defaulted quit key to 81 at app bootstrap, to make it 27 we have to specify it for each modal config
-    static modalConfigs = {
-        'large': new ModalConfig("lg", false, 27),
-        'small': new ModalConfig("sm", false, 27),
-        'yesno': new ModalConfig("sm", false, 27),
-        'key': undefined, // Modal will use default config, which we set at app bootstrap (setting in app bootstrap is optional)
-        'blocking': new ModalConfig("lg", true, null), // null for keyboard means no keyboard keys can close the modal.
-        'inElement': new ModalConfig("lg", true, null),
-        'customWindow': new ModalConfig("lg", true, 27)
-    };
-    static modalData = {
-        'large': new YesNoModalContent('Simple Large modal', 'Press ESC or click OK / outside area to close.', true),
-        'small': new YesNoModalContent('Simple Small modal', 'Press ESC or click OK / outside area to close.', true),
-        'yesno': new YesNoModalContent('Simple 2 button custom modal', 'Answer the question', false, "Yes", "No"),
-        'key': new YesNoModalContent('Special Exit Key', 'Press q to close.', true),
-        'blocking': new YesNoModalContent('Simple Blocking modal', 'You can only click OK to close this modal.', true),
-        'inElement':new YesNoModalContent('Simple In Element modal', 'Try stacking more modals, click OK to close.', true),
-        'customWindow': new AdditionCalculateWindowData(2, 3)
-    };
-    /* tslint:enable */
-
-    openDialog(type: string) {
-        let dialog:  Promise<ModalDialogInstance>;
-        let component = (type === 'customWindow') ? AdditionCalculateWindow : YesNoModal;
-        let bindings = Injector.resolve([
-            provide(ICustomModal, {useValue: DemoPage.modalData[type]})
-        ]);
-
-        if (type === 'inElement') {
-            dialog = this.modal.openInside(
-                <any>component,
-                this.mySampleElement,
-                'myModal',
-                bindings,
-                DemoPage.modalConfigs[type]);
-        } else
-            dialog = this.modal.open(
-                <any>component,
-                bindings,
-                DemoPage.modalConfigs[type]);
-
-
+    processDialog(dialog: Promise<ModalDialogInstance>) {
         dialog.then((resultPromise) => {
             return resultPromise.result.then((result) => {
                 this.lastModalResult = result;
             }, () => this.lastModalResult = 'Rejected!');
         });
+    }
+    open(btn) {
+        let dialog,
+            preset = btn.preset(this.modal);
+        if (btn.text === 'In Element') {
+            dialog = preset.open({
+                elementRef: this.mySampleElement,
+                anchorName: 'myModal'
+            });
+        } else {
+            dialog = preset.open();
+        }
+
+        this.processDialog(dialog);
+    }
+
+
+    openCustomModal() {
+        let resolvedBindings = Injector.resolve([provide(ICustomModal, {
+                                                useValue: new AdditionCalculateWindowData(2, 3)})]),
+            dialog = this.modal.open(
+                <any>AdditionCalculateWindow,
+                resolvedBindings,
+                new ModalConfig('lg', true, 27)
+        );
+       this.processDialog(dialog);
     }
 }

--- a/src/demo/app/demoPage/presets.ts
+++ b/src/demo/app/demoPage/presets.ts
@@ -1,0 +1,82 @@
+import {Modal} from 'angular2-modal';
+
+export function alert(modal: Modal) {
+    return modal.alert()
+        .size('lg')
+        .title('A simple Alert style modal window')
+        .body(`
+        <h4>Alert is a classic (title/body/footer) 1 button modal window that 
+        does not block.</h4>
+        <b>Configuration:</b>
+        <ul>
+            <li>Non blocking (click anywhere outside to dismiss)</li>
+            <li>Size large</li>
+            <li>Dismissed with default keyboard key (ESC)</li>
+            <li>Close wth button click</li>
+            <li>HTML content</li>
+        </ul>`);
+}
+
+export function prompt(modal: Modal) {
+    return modal.prompt()
+        .size('lg')
+        .title('A simple Prompt style modal window')
+        .body(`
+            <h4>Prompt is a classic (title/body/footer) 1 button modal window that 
+            blocks.</h4>
+            <b>Configuration:</b>
+            <ul>
+                <li>Blocks (only button click can dismiss)</li>
+                <li>Size large</li>
+                <li>Keyboard can not dismiss</li>
+                <li>HTML content</li>
+            </ul>`);
+}
+
+export function confirm(modal: Modal) {
+    return modal.confirm()
+        .size('lg')
+        .titleHtml(`
+            <div class="modal-title" 
+                 style="font-size: 22px; color: grey; text-decoration: underline;">
+                 A simple Confirm style modal window</div>`)
+        .body(`
+            <h4>Confirm is a classic (title/body/footer) 2 button modal window that blocks.</h4>
+            <b>Configuration:</b>
+            <ul>
+                <li>Blocks (only button click can close/dismiss)</li>
+                <li>Size large</li>
+                <li>Keyboard can not dismiss</li>
+                <li>HTML Title</li>
+                <li>HTML content</li>
+            </ul>`);
+}
+
+export function cascading(modal: Modal) {
+    let presets = [];
+
+    presets.push(alert(modal));
+    presets.push(prompt(modal));
+    presets.push(confirm(modal));
+    presets.push(
+        modal.prompt()
+            .size('sm')
+            .title('Cascading modals!')
+            .body('Find your way out...')
+    );
+
+    return {
+        open: () => {
+            let ret = presets.shift().open();
+            while (presets.length > 0) presets.shift().open();
+            return ret;
+        }
+    };
+}
+
+export function inElement(modal: Modal) {
+    return modal.prompt()
+        .size('sm')
+        .title('A modal contained by an element')
+        .body('Try stacking up more modals!');
+}

--- a/src/demo/bootstrap.ts
+++ b/src/demo/bootstrap.ts
@@ -1,6 +1,6 @@
 import {provide} from 'angular2/core';
 import {bootstrap} from 'angular2/platform/browser';
-import {ROUTER_PROVIDERS} from 'angular2/router';
+import {ROUTER_PROVIDERS, LocationStrategy, HashLocationStrategy} from 'angular2/router';
 import {ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/common_dom';
 // include for production builds
 // import {enableProdMode} from 'angular2/core';
@@ -13,6 +13,7 @@ import {ModalConfig} from 'angular2-modal';
 function main() {
     return bootstrap(App, [
         ROUTER_PROVIDERS,
+        provide(LocationStrategy, {useClass: HashLocationStrategy}),
         // set a custom default options for the modal.
         provide(ModalConfig, {useValue: new ModalConfig('lg', true, 81)}),
         ELEMENT_PROBE_PROVIDERS // remove in production

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
 
     entry: {
         'vendor': './src/demo/vendor.ts',
+        'angular2-modal': './angular2-modal.ts',
         'app': './src/demo/bootstrap.ts' // our angular app
     },
 


### PR DESCRIPTION
Closes  #33 
Closes #36 
Closes #17 

(feat) Simplify API - Added the Preset API using fluent API  approach the API is now easier to use while saving backward computability.
(feat) Allow extending the Preset API - All presets are built using composition of core classes so Preset can be built from scratch.
(feat) Provide built in Presets: alert, prompt and confirm.
(refactor) Built a class component modal (MessageModal) that can be customized.
(feat) Support custom HTML and dynamic CSS classes, N number of button, button text/css, title&body text/html/css, header/footer css
(misc) Integrate MessageModal with Presets
(misc) Deprecate okOnlyModal and yesNoModal as they are not needed anymore.