### PR TITLE
typing path error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Shlomi Assaf",
   "license": "MIT",
   "main": "dist/commonjs/angular2-modal.js",
-  "typings": "./dist/angular2-modal.d.ts",
+  "typings": "dist/commonjs/angular2-modal.d.ts",
   "homepage": "https://github.com/shlomiassaf/angular2-modal",
   "bugs": {
     "url": "https://github.com/shlomiassaf/angular2-modal/issues"


### PR DESCRIPTION
TS compiler can't find "angular2-modal" module
typings path in `package.json` seems to be wrong