### PR TITLE
Support angualr2@2.0.0-beta.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Breaking changing from 0.1.4 to 0.1.5 (angular2 beta 15 to beta 17)
+
+## Design
+  * Angular 2s component interaction is now centered around `ViewContainerRef` which are logical units of view's, `angular2-modal` followed.
+  * A default `ViewContainerRef` is needed for `angular2-modal`. This is done once (in 99%) and from there on you can forget about `ViewContainerRef`.
+    This is 1 new code line, the other option was to force a mandatory element in the root template.
+  * The way **dependency injection** is used is now very important.
+    Since a Modal instance is paired with a default view container, every new instance of the modal requires setting a new default view container.
+    This can be handy for advanced scenarios but for most cases setting the default view container once is what you should do. 
+    If you set it once from in the top level component don’t request the Modal in the providers property of a component meta, if you do so you will get a new instance of `Modal`.
+    **This is how a setting it once looks:**
+    ```ts
+    @Component({
+        selector: 'app', 
+        providers: [ ...MODAL_PROVIDERS], // list of angular2-modal tokens, Modal included.
+        template: `
+        <main>
+          <router-outlet></router-outlet>
+        </main>
+      `
+    })
+    export class App {
+        constructor(public modal: Modal, viewContainer: ViewContainerRef) {
+            /**
+             * A Default view container ref, usually the app root container ref.
+             * Has to be set manually until we can find a way to get it automatically.
+             */
+            modal.defaultViewContainer = viewContainer;
+        }
+    }
+    ```
+    From here on, there's no need to require a new provider for `Modal`      
+    So **don't** do this:
+    ```ts
+        @Component({
+            selector: 'myComponent', 
+            providers: [Modal], // results in a brand new instance of Modal
+            template: `<h1>My Component></h1>`
+        })
+        export class MyComponent {}
+    ```
+
+## Generic type changes from angular2@2.0.0-beta.16
+  * Every `ResolveProvider` is now `ResolvedReflectiveProviders`
+  * Every `Injector` is now `ReflectiveInjector`
+
+## Class changes:
+#### BootstrapModalContainer: 
+  * Change selector from `bootstrap-modal` to `modal-container`
+
+#### Modal:
+  * open() and openInside() now get ViewContainerRef instead of ElementRef
+  * openInside() anchor parameter was removed
+  * Added property defaultViewContainer, to be set on initial root app element load.
+
+#### ModalDialogInstance: 
+  * Change method dispose() to destroy()
+  * Does not store a reference to Backdrop and BootstrapContainer ComponentRef
+  * Destroy is now set by the Modal service, DialogRef starts with a noop destroy functionality
+
+#### ModalAwarePreset: 
+  * open method now get 1 optional parameter ViewContainerRef instead of the inside object.
+    If supplied it modal will render inside that view, otherwise use the defaultViewContainer
+
+## Demo:
+Sample element is now modal agnostic, use parent component to get ViewContainerRef

--- a/README.md
+++ b/README.md
@@ -1,15 +1,42 @@
-# Angular 2: Modal/Dialog window (with Bootstrap presets).
+# Angular 2 (beta.17): Modal/Dialog window (with Bootstrap presets).
 
 A fully generic, customizable and fluent modal window implementation for Angular 2 with built in Bootstrap support.  
 Generic means it can support any CSS framework or be a standalone, supply a Component, replace some Tokens and add some presets (optional) and you have an identical fluent API modal for your framework of choice.
 
->**DISCLAIMER**  
->
->Angular 2 is still in the works. The core concepts are solid, but the API may change. If you find that a code snippet that does not work, please message me, and I will update.
+>**DISCLAIMER**
+Angular 2 is still in the works. The core concepts are solid, but the API may change. If you find that a code snippet that does not work, please message me, and I will update.
  
-## Built with angular 2 Beta
+## Built with angular 2 Beta 17
 
-## Features:  
+## Breaking changing from 0.1.4 to 0.1.5 (angular2 beta 15 to beta 17)
+See [here](https://github.com/shlomiassaf/angular2-modal/tree/master/CHANGELOG.md)
+
+## Note: Next major version, 1.0.0
+The next major version of angular2-modal will be ui platform/framework agnostic.
+
+UI platforms/framework will describe their UI implementation and register with `angular2-modal` via angular's DI module.  
+This means virtually any modal implementation out there can be ported into `angular2-modal`.
+`angular2-modal' will come with some built in UI platforms, external UI platform can be added in the future or externally used using NPM modules.
+
+`angular2-modal` makes heavy use of angular's dependency injection module to provide abstraction around modal creation so creating a plugin is straight forward.
+This will also make customization a lot easier.
+##### The current beta of 1.0.0 implements the following UI platforms:
+  
+  * Bootstrap's modal
+  * [Vex](http://github.hubspot.com/vex/docs/welcome/) (WIP) 
+  * POC implementation of JS Native modal (window.alert/prompt/confirm) to demonstrate a hostile takeover :)
+
+Developer's using ES6 modules will import the providers for the UI platform of their choice.
+
+End users of `angular2-modal` should expect mild breaking API changes in 1.0.0   
+If you are currently extending `angular2-modal` you should expect some refactoring of your work. 1.0.0 include changes in:
+  * File structure (UI platform holds it's own presets...)
+  * File naming convention (moving to snake-case)
+  * The logic to extend `angular2-modal`
+  
+1.0.0 is 70% complete.  
+ 
+## Features  
 
   - Easy to use API via Fluent API Presets (alert, propmt, confirm)
   - Fully customizable.
@@ -44,38 +71,6 @@ See [src/demo](https://github.com/shlomiassaf/angular2-modal/tree/master/src/dem
 
 Will try to add documented examples if time allows.
 
-## ~~Known issue - DI exception:~~  
-Issues fixed in angular2.0-beta.6
-
-~~If you encounter a version of the following exception:~~
-
-```
-EXCEPTION: No provider for XXXXX! (YYYYY -> XXXXX)
-```
-
-~~Where YYYYY will usually be a directive you've injected to a custom modal component you've built.~~
-
-~~This is an error raised by angular core because it can't find a resolved providers for injectable tokens request by~~
-~~the directive/s you want to use within your component.~~
-~~These providers are common runtime objects that angular should know how to fetch, even if not defined.~~
-~~There is a bug opend here [angular/angular#4330](https://github.com/angular/angular/issues/4330).~~
-
-~~To workaround this issue supply these values in the resolved bindings array sent as a parameter ~~
-~~to "open" or "openInside" calls.~~
-
-    let bindings = Injector.resolve([
-                provide(IterableDiffers, {useValue: this.injector.get(IterableDiffers)}),
-                provide(KeyValueDiffers, {useValue: this.injector.get(KeyValueDiffers)}),
-                provide(Renderer, {useValue: this.injector.get(Renderer)})
-            ]);
-                   
-    let dialog = modal.openInside(..., ..., ..., bindings, ...);
-
-~~click for [example](https://github.com/shlomiassaf/angular2-modal/blob/master/src/demo/app/demoPage/demoPage.ts#L58-L63)~~
-
-~~Another workaround that might work is to supply the resolved providers as part of the bootstrap process. ~~
-~~I'm not sure it will work as it depends on the life cycle logic of the injected values which I don't know deeply enough.~~
-~~If you got it to work let me know.~~
 
 ## Installation
 ```
@@ -101,20 +96,6 @@ I created a `publish` directory instead and set the `--project` argument accordi
 # Issues and TODO's
 ## Animation
 Not so complicated but not in angular 2 at the moment.
-
-## Module
-Set webpack do build angular2-module.js as an initial webpack module (currently its not...)
-This will allow using it as an input for other projects.
-
-## ~~Minimize DOM interaction~~
-~~Reduce manual DOM interaction, do more usage of `host` object in `@Component`.~~
-~~Append child to the DOM using the angular 2 way, if you know tell me.~~
- 
-## Allow Element blocking modal to be set on any element.
-Currently blocking an element requires it to have an angular template variable placed in one of his children.
-This is due to the current angular implementation, as I see it.
-I have yet to find an angular way of inserting a compiled element to a native element/component without effecting it.
-See issue [6071](https://github.com/angular/angular/issues/6071)
 
 ## Bootstrap free / ShadowDOM
 Make it fly solo....

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular2-modal",
   "description": "Angular2 Modal (dialog) window bootstrap style.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/shlomiassaf/angular2-modal.git"
@@ -24,7 +24,7 @@
     "prepublish": "tsc --project publish && node make.js"
   },
   "peerDependencies": {
-    "angular2": "2.0.0-beta.15"
+    "angular2": "2.0.0-beta.17"
   },
   "devDependencies": {
     "async": "^1.5.2",

--- a/src/components/angular2-modal/components/bootstrapModalContainer.ts
+++ b/src/components/angular2-modal/components/bootstrapModalContainer.ts
@@ -1,15 +1,21 @@
-import { Component } from 'angular2/core';
+import {
+    Component,
+    DynamicComponentLoader,
+    ViewContainerRef,
+    ViewChild,
+    AfterViewInit
+} from 'angular2/core';
+
 import {ModalDialogInstance} from '../models/ModalDialogInstance';
-import {Modal} from '../providers/Modal';
+import {Modal, ModalCompileConfig} from '../providers/Modal';
 
 /**
  * A component that acts as a top level container for an open modal window.
  */
 @Component({
-    selector: 'bootstrap-modal',
-    providers: [Modal],
+    selector: 'modal-container',
     host: {
-        'tabindex': '0',
+        'tabindex': '-1',
         'role': 'dialog',
         'class': 'in modal',
         'style': 'display: block',
@@ -19,45 +25,55 @@ import {Modal} from '../providers/Modal';
     },
     /* tslint:disable */
     template:
-    `<div [ngClass]="dialogInstance.config.dialogClass"
-          [class.modal-lg]="dialogInstance.config.size == \'lg\'"
-          [class.modal-sm]="dialogInstance.config.size == \'sm\'">
-         <div class="modal-content" (click)="onContainerClick($event)" style="display: block">
+    `<div [ngClass]="dialog.config.dialogClass"
+          [class.modal-lg]="dialog.config.size == \'lg\'"
+          [class.modal-sm]="dialog.config.size == \'sm\'">
+         <div class="modal-content" 
+              role="document"
+              style="display: block"
+              (click)="onContainerClick($event)">
             <div style="display: none" #modalDialog></div>
          </div>
     </div>`
-    //TODO: #modalDialog element is not needed but dynamicComponentLoader doesn't seem to have behavior to inject a component the way we want.
-    //      We need to replace the #modalDialog element but the current implementation only adds it as a sibling.
-    //      see https://github.com/angular/angular/issues/6071
     /* tslint:enable */
 })
-export class BootstrapModalContainer {
-    dialogInstance: ModalDialogInstance;
+export class BootstrapModalContainer implements AfterViewInit {
     public position: string;
-
-    constructor(dialogInstance: ModalDialogInstance, private modal: Modal) {
-        this.dialogInstance = dialogInstance;
-        if (!dialogInstance.inElement) {
+    @ViewChild('modalDialog', {read: ViewContainerRef}) private _viewContainer: ViewContainerRef;
+    
+    constructor(public dialog: ModalDialogInstance,
+                private _modal: Modal,
+                private _dlc: DynamicComponentLoader,
+                private _compileConfig: ModalCompileConfig) {
+        if (!dialog.inElement) {
             this.position = null;
         } else {
             this.position = 'absolute';
         }
     }
 
+    ngAfterViewInit() {
+        this._dlc
+            .loadNextToLocation(this._compileConfig.component,
+                this._viewContainer,
+                this._compileConfig.bindings)
+            .then(contentRef => this.dialog.contentRef = contentRef);
+    }
+    
     onContainerClick($event: any) {
         $event.stopPropagation();
     }
 
     onClick() {
-        return !this.dialogInstance.config.isBlocking && this.dialogInstance.dismiss();
+        return !this.dialog.config.isBlocking && this.dialog.dismiss();
     }
 
     documentKeypress(event: KeyboardEvent) {
         // check that this modal is the last in the stack.
-        if (this.modal.stackPosition(this.dialogInstance) !== this.modal.stackLength - 1) return;
+        if (this._modal.stackPosition(this.dialog) !== this._modal.stackLength - 1) return;
 
-        if (this.dialogInstance.config.supportsKey(event.keyCode)) {
-            this.dialogInstance.dismiss();
+        if (this.dialog.config.supportsKey(event.keyCode)) {
+            this.dialog.dismiss();
         }
     }
 }

--- a/src/components/angular2-modal/components/modalBackdrop.ts
+++ b/src/components/angular2-modal/components/modalBackdrop.ts
@@ -1,6 +1,6 @@
-import { Component } from 'angular2/core';
+import {Component} from 'angular2/core';
 import {ModalDialogInstance} from '../models/ModalDialogInstance';
-
+import {BootstrapModalContainer} from './bootstrapModalContainer';
 
 /**
  * Represents the modal backdrop.
@@ -17,7 +17,10 @@ import {ModalDialogInstance} from '../models/ModalDialogInstance';
         '[style.bottom]': 'bottom'
 
     },
-    template: '<div [style.position]="position" class="in modal-backdrop" #modalBackdrop></div>'
+    directives: [BootstrapModalContainer],
+    template:
+`<div [style.position]="position" class="modal-backdrop fade in"></div>
+<modal-container></modal-container>`
 })
 export class ModalBackdrop {
     public position: string;

--- a/src/components/angular2-modal/components/modalFooter.ts
+++ b/src/components/angular2-modal/components/modalFooter.ts
@@ -13,7 +13,7 @@ export interface FooterButtonClickEvent {
     selector: 'modal-footer',
     template:
 `<div [ngClass]="footerClass">
-    <button *ngFor="#btn of buttons;"
+    <button *ngFor="let btn of buttons;"
             [ngClass]="btn.cssClass"
             (click)="onClick(btn, $event)">{{btn.caption}}</button>
 </div>`

--- a/src/components/angular2-modal/models/ModalDialogInstance.ts
+++ b/src/components/angular2-modal/models/ModalDialogInstance.ts
@@ -13,19 +13,10 @@ export class ModalDialogInstance {
      */
     public inElement: boolean;
 
-    private _bootstrapRef: ComponentRef;
-    private _backdropRef: ComponentRef;
-    private _resultDefered: any;
+    private _resultDeferred: any;
 
     constructor(public config: ModalConfig) {
-        this._resultDefered = PromiseWrapper.completer();
-    }
-
-    set backdropRef(value: ComponentRef) {
-        this._backdropRef = value;
-    }
-    set bootstrapRef(value: ComponentRef) {
-        this._bootstrapRef = value;
+        this._resultDeferred = PromiseWrapper.completer();
     }
 
     /**
@@ -33,7 +24,7 @@ export class ModalDialogInstance {
      * @returns {Promise<T>|any|*|Promise<any>}
      */
     get result(): Promise<any> {
-        return this._resultDefered.promise;
+        return this._resultDeferred.promise;
     }
 
     /**
@@ -42,8 +33,8 @@ export class ModalDialogInstance {
     close(result: any = null) {
         if ( this.contentRef.instance.beforeClose &&
                 this.contentRef.instance.beforeClose() === true ) return;
-        this.dispose();
-        this._resultDefered.resolve(result);
+        this.destroy();
+        this._resultDeferred.resolve(result);
     }
 
     /**
@@ -56,13 +47,9 @@ export class ModalDialogInstance {
     dismiss() {
         if ( this.contentRef.instance.beforeDismiss &&
             this.contentRef.instance.beforeDismiss() === true ) return;
-        this.dispose();
-        this._resultDefered.reject();
+        this.destroy();
+        this._resultDeferred.reject();
     }
 
-    private dispose() {
-        this._bootstrapRef.dispose();
-        this._backdropRef.dispose();
-        this.contentRef.dispose();
-    }
+    public destroy() {}
 }

--- a/src/components/angular2-modal/presets/OneButtonPreset.ts
+++ b/src/components/angular2-modal/presets/OneButtonPreset.ts
@@ -1,4 +1,4 @@
-import { Injector, provide , ResolvedBinding} from 'angular2/core';
+import { ReflectiveInjector, provide , ResolvedReflectiveBinding} from 'angular2/core';
 import {FluentAssignMethod} from '../framework/FluentAssign';
 import {Modal} from '../providers/Modal';
 import {MessageModalContext, MessageModal} from '../modals/MessageModal';
@@ -6,7 +6,7 @@ import {MessageModalPreset, MessageModalPresetData} from './base/MessageModalPre
 import {extend} from '../framework/Utils';
 
 
-function createBindings(config: OneButtonPresetData): ResolvedBinding[] {
+function createBindings(config: OneButtonPresetData): ResolvedReflectiveBinding[] {
     config.buttons = [
         {
             cssClass: config.okBtnClass,
@@ -16,7 +16,7 @@ function createBindings(config: OneButtonPresetData): ResolvedBinding[] {
         }
     ];
 
-    return Injector.resolve([
+    return ReflectiveInjector.resolve([
         provide(MessageModalContext, {useValue: config})
     ]);
 }

--- a/src/components/angular2-modal/presets/TwoButtonPreset.ts
+++ b/src/components/angular2-modal/presets/TwoButtonPreset.ts
@@ -1,4 +1,4 @@
-import { Injector, provide , ResolvedBinding} from 'angular2/core';
+import { ReflectiveInjector, provide , ResolvedReflectiveBinding} from 'angular2/core';
 import {FluentAssignMethod} from '../framework/FluentAssign';
 import {extend} from '../framework/Utils';
 import {Modal} from '../providers/Modal';
@@ -7,7 +7,7 @@ import {MessageModalPreset} from './base/MessageModalPreset';
 import {OneButtonPresetData} from './OneButtonPreset';
 
 
-function createBindings(config: TwoButtonPresetData): ResolvedBinding[] {
+function createBindings(config: TwoButtonPresetData): ResolvedReflectiveBinding[] {
     config.buttons = [
         {
             cssClass: config.okBtnClass,
@@ -23,7 +23,7 @@ function createBindings(config: TwoButtonPresetData): ResolvedBinding[] {
         }
     ];
 
-    return Injector.resolve([
+    return ReflectiveInjector.resolve([
         provide(MessageModalContext, {useValue: config})
     ]);
 }

--- a/src/components/angular2-modal/presets/base/ModalAwarePreset.ts
+++ b/src/components/angular2-modal/presets/base/ModalAwarePreset.ts
@@ -1,4 +1,4 @@
-import { ResolvedProvider, ElementRef } from 'angular2/core';
+import { ResolvedReflectiveProvider, ViewContainerRef } from 'angular2/core';
 import {Modal} from '../../providers/Modal';
 import {IModalConfig, ModalConfig, BootstrapModalSize} from '../../models/ModalConfig';
 import {FluentAssign, FluentAssignMethod, setAssignMethod} from './../../framework/FluentAssign';
@@ -7,7 +7,7 @@ import {ModalDialogInstance} from '../../models/ModalDialogInstance';
 export interface ModalAwarePresetData extends IModalConfig {
     component: any;
     modal: Modal;
-    bindings: <T>(config: T) => ResolvedProvider[];
+    bindings: <T>(config: T) => ResolvedReflectiveProvider[];
 }
 
 
@@ -67,7 +67,7 @@ export class ModalAwarePreset<T extends ModalAwarePresetData> extends FluentAssi
      * @param inside If set opens the modal inside the supplied elements ref at the specified anchor
      * @returns Promise<ModalDialogInstance>
      */
-    open(inside?: {elementRef: ElementRef, anchorName: string}): Promise<ModalDialogInstance> {
+    open(viewContainer?: ViewContainerRef): Promise<ModalDialogInstance> {
         let config: T = this.toJSON();
 
         if (! (config.modal instanceof Modal) ) {
@@ -78,20 +78,23 @@ export class ModalAwarePreset<T extends ModalAwarePresetData> extends FluentAssi
             return <any>Promise.reject(new Error('Configuration Error: bindings not set.'));
         }
 
-        if (inside) {
+        if (viewContainer) {
             // TODO: Validate inside?
-            return config.modal.openInside(config.component,
-                inside.elementRef,
-                inside.anchorName,
+            return config.modal.openInside(
+                config.component,
+                viewContainer,
                 config.bindings(config),
-                new ModalConfig(config.size, config.isBlocking, config.keyboard));
+                new ModalConfig(config.size, config.isBlocking, config.keyboard)
+        );
         } else {
-            return config.modal.open(config.component,
+            return config.modal.open(
+                config.component,
                 config.bindings(config),
                 new ModalConfig(config.size,
                     config.isBlocking,
                     config.keyboard,
-                    config.dialogClass));
+                    config.dialogClass)
+            );
         }
     }
 }

--- a/src/demo/app/app.ts
+++ b/src/demo/app/app.ts
@@ -1,7 +1,8 @@
-import {Component} from 'angular2/core';
+import {Component, ViewContainerRef} from 'angular2/core';
 import {RouteConfig, ROUTER_DIRECTIVES} from 'angular2/router';
 import {FORM_PROVIDERS} from 'angular2/common';
 
+import {Modal, MODAL_PROVIDERS} from 'angular2-modal';
 import {DemoPage} from './demoPage/demoPage';
 import {CustomizeWizard} from './customizeWizard/customizeWizard';
 /*
@@ -11,7 +12,7 @@ import {CustomizeWizard} from './customizeWizard/customizeWizard';
 @Component({
     selector: 'app', // <app></app>
     // We need to tell Angular's Dependency Injection which providers are in our app.
-    providers: [ ...FORM_PROVIDERS],
+    providers: [ ...FORM_PROVIDERS, ...MODAL_PROVIDERS],
     // We need to tell Angular's compiler which directives are in our template.
     // Doing so will allow Angular to attach our behavior to an element
     directives: [ ...ROUTER_DIRECTIVES],
@@ -31,5 +32,11 @@ import {CustomizeWizard} from './customizeWizard/customizeWizard';
     { path: '/customizeModals', component: CustomizeWizard, name: 'CustomizeModals' }
 ])
 export class App {
-    constructor() {}
+    constructor(public modal: Modal, viewContainer: ViewContainerRef) {
+        /**
+         * A Default view container ref, usually the app root container ref.
+         * Has to be set manually until we can find a way to get it automatically.
+         */
+        modal.defaultViewContainer = viewContainer;
+    }
 }

--- a/src/demo/app/customModalDemo/customModal.ts
+++ b/src/demo/app/customModalDemo/customModal.ts
@@ -1,7 +1,6 @@
-import {Component, Input} from 'angular2/core';
-import {CORE_DIRECTIVES} from 'angular2/common';
+import {Component} from 'angular2/core';
 
-import {Modal, ModalDialogInstance, ICustomModal, ICustomModalComponent} from 'angular2-modal';
+import {ModalDialogInstance, ICustomModal, ICustomModalComponent} from 'angular2-modal';
 
 export class AdditionCalculateWindowData {
     constructor(
@@ -15,7 +14,6 @@ export class AdditionCalculateWindowData {
  */
 @Component({
     selector: 'modal-content',
-    directives: [CORE_DIRECTIVES],
     styles: [`
         .custom-modal-container {
             padding: 15px;

--- a/src/demo/app/customizeWizard/customizeWizard.ts
+++ b/src/demo/app/customizeWizard/customizeWizard.ts
@@ -1,12 +1,10 @@
-import { Component } from 'angular2/core';
+import {Component} from 'angular2/core';
 import {Modal, TwoButtonPresetData, TwoButtonPreset} from 'angular2-modal';
 let html = require('./customizeWizard.tpl.html');
 
 
 @Component({
     selector: 'customize-wizard',
-    directives: [],
-    providers: [Modal],
     template: html
 })
 export class CustomizeWizard {

--- a/src/demo/app/demoPage/demoPage.tpl.html
+++ b/src/demo/app/demoPage/demoPage.tpl.html
@@ -4,7 +4,7 @@
     <br>
     <div class="row">
         <div class="col-xs-12">
-            <button *ngFor="#btn of buttons;"
+            <button *ngFor="let btn of buttons;"
                     class="btn btn-default"
                     (click)="open(btn)">{{btn.text}}</button>
             <button class="btn btn-default" (click)="openCustomModal()">Custom Modal</button>

--- a/src/demo/app/demoPage/demoPage.ts
+++ b/src/demo/app/demoPage/demoPage.ts
@@ -1,4 +1,4 @@
-import { Component, provide, ElementRef, Injector} from 'angular2/core';
+import {Component, provide, ViewContainerRef, ReflectiveInjector, ViewChild} from 'angular2/core';
 import {RouterLink} from 'angular2/router';
 import {ModalConfig, Modal, ICustomModal, ModalDialogInstance} from 'angular2-modal';
 import {AdditionCalculateWindowData, AdditionCalculateWindow} from '../customModalDemo/customModal';
@@ -31,14 +31,14 @@ const BUTTONS = [
 @Component({
     selector: 'demo-page',
     directives: [SampleElement, RouterLink],
-    providers: [Modal],
     styles: [ require('./demoPage.css') ],
     template: require('./demoPage.tpl.html')
 })
 export class DemoPage {
-    public mySampleElement: ElementRef;
     public lastModalResult: string;
     public buttons = BUTTONS;
+    @ViewChild(SampleElement, {read: ViewContainerRef}) private mySampleElement: ViewContainerRef;
+
     constructor(private modal: Modal) {}
 
     processDialog(dialog: Promise<ModalDialogInstance>) {
@@ -52,10 +52,7 @@ export class DemoPage {
         let dialog,
             preset = btn.preset(this.modal);
         if (btn.text === 'In Element') {
-            dialog = preset.open({
-                elementRef: this.mySampleElement,
-                anchorName: 'myModal'
-            });
+            dialog = preset.open(this.mySampleElement);
         } else {
             dialog = preset.open();
         }
@@ -65,7 +62,7 @@ export class DemoPage {
 
 
     openCustomModal() {
-        let resolvedBindings = Injector.resolve([provide(ICustomModal, {
+        let resolvedBindings = ReflectiveInjector.resolve([provide(ICustomModal, {
                                                 useValue: new AdditionCalculateWindowData(2, 3)})]),
             dialog = this.modal.open(
                 <any>AdditionCalculateWindow,

--- a/src/demo/app/sampleElement/sampleElement.ts
+++ b/src/demo/app/sampleElement/sampleElement.ts
@@ -1,19 +1,15 @@
-import {Component, ElementRef, Inject, forwardRef} from 'angular2/core';
-import {DemoPage} from '../demoPage/demoPage';
+import {Component} from 'angular2/core';
 
 @Component({
     selector: 'sample-element',
     template:
-    `<div>
+        `<div>
         <h1>I Am an Element!</h1>
         <p>I can be modaled!</p>
      </div>
-     <div #myModal></div>
+     <div></div>
      `
 })
 export class SampleElement {
-    constructor( @Inject(forwardRef(() => DemoPage)) demoPage: DemoPage, elementRef: ElementRef) {
-        //TODO: Replace with querying instead of letting the DI decide?
-        demoPage.mySampleElement = elementRef;
-    }
+    constructor() {}
 }

--- a/src/demo/bootstrap.ts
+++ b/src/demo/bootstrap.ts
@@ -1,6 +1,7 @@
 import {provide} from 'angular2/core';
 import {bootstrap} from 'angular2/platform/browser';
-import {ROUTER_PROVIDERS, LocationStrategy, HashLocationStrategy} from 'angular2/router';
+import {ROUTER_PROVIDERS} from 'angular2/router';
+import {LocationStrategy, HashLocationStrategy} from 'angular2/platform/common';
 import {ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/common_dom';
 // include for production builds
 // import {enableProdMode} from 'angular2/core';
@@ -14,8 +15,6 @@ function main() {
     return bootstrap(App, [
         ROUTER_PROVIDERS,
         provide(LocationStrategy, {useClass: HashLocationStrategy}),
-        // set a custom default options for the modal.
-        provide(ModalConfig, {useValue: new ModalConfig('lg', true, 81)}),
         ELEMENT_PROBE_PROVIDERS // remove in production
     ])
         .catch(err => console.error(err));


### PR DESCRIPTION
## Design
  * Angular 2s component interaction is now centered around `ViewContainerRef` which are logical units of view's, `angular2-modal` followed.
  * A default `ViewContainerRef` is needed for `angular2-modal`. This is done once (in 99%) and from there on you can forget about `ViewContainerRef`.
    This is 1 new code line, the other option was to force a mandatory element in the root template.
  * The way **dependency injection** is used is now very important.
    Since a Modal instance is paired with a default view container, every new instance of the modal requires setting a new default view container.
    This can be handy for advanced scenarios but for most cases setting the default view container once is what you should do.
    If you set it once from in the top level component don’t request the Modal in the providers property of a component meta, if you do so you will get a new instance of `Modal`.
    **This is how a setting it once looks:**
```ts
    @Component({
        selector: 'app',
        providers: [ ...MODAL_PROVIDERS], // list of angular2-modal tokens, Modal included.
        template: `
        <main>
          <router-outlet></router-outlet>
        </main>
      `
    })
    export class App {
        constructor(public modal: Modal, viewContainer: ViewContainerRef) {
            /**
             * A Default view container ref, usually the app root container ref.
             * Has to be set manually until we can find a way to get it automatically.
             */
            modal.defaultViewContainer = viewContainer;
        }
    }
```
From here on, there's no need to require a new provider for `Modal`
So **don't** do this:
```ts
        @Component({
            selector: 'myComponent',
            providers: [Modal], // results in a brand new instance of Modal
            template: `<h1>My Component></h1>`
        })
        export class MyComponent {}
```

## Generic type changes from angular2@2.0.0-beta.16
  * Every `ResolveProvider` is now `ResolvedReflectiveProviders`
  * Every `Injector` is now `ReflectiveInjector`

## Class changes:
#### BootstrapModalContainer:
  * Change selector from `bootstrap-modal` to `modal-container`

#### Modal:
  * open() and openInside() now get ViewContainerRef instead of ElementRef
  * openInside() anchor parameter was removed
  * Added property defaultViewContainer, to be set on initial root app element load.

#### ModalDialogInstance:
  * Change method dispose() to destroy()
  * Does not store a reference to Backdrop and BootstrapContainer ComponentRef
  * Destroy is now set by the Modal service, DialogRef starts with a noop destroy functionality

#### ModalAwarePreset:
  * open method now get 1 optional parameter ViewContainerRef instead of the inside object.
    If supplied it modal will render inside that view, otherwise use the defaultViewContainer

## Demo:
Sample element is now modal agnostic, use parent component to get ViewContainerRef