### PR TITLE
dialogClass only accepts sm/lg it should accept a string, eg. modal-dialog

### DIFF
--- a/src/components/angular2-modal/plugins/bootstrap/modal-context.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/modal-context.ts
@@ -77,7 +77,7 @@ export class BSModalContextBuilder<T extends BSModalContext> extends ModalOpenCo
      * A Class for the modal dialog container.
      * Default: modal-dialog
      */
-    dialogClass: FluentAssignMethod<BootstrapModalSize, this>;
+    dialogClass: FluentAssignMethod<string, this>;
 
     /**
      * When true, show a close button on the top right corner.


### PR DESCRIPTION
`dialogClass` should accept a `string` instead of `BootstrapModalSize`
