### PR TITLE
Modal.ts: `component` type change in `open`,`openInside`

### DIFF
--- a/src/components/angular2-modal/providers/Modal.ts
+++ b/src/components/angular2-modal/providers/Modal.ts
@@ -70,10 +70,12 @@ export class Modal {
      * @param config A Modal Configuration object.
      * @returns {Promise<ModalDialogInstance>}
      */
+    public open(component: Type, config?: ModalConfig): Promise<ModalDialogInstance>;
+    public open(component: Type, bindings?: ResolvedReflectiveProvider[], config?: ModalConfig): Promise<ModalDialogInstance>;
     public open(component: Type,
-                bindings: ResolvedReflectiveProvider[],
-                config?: ModalConfig): Promise<ModalDialogInstance> {
-        return this.openInside(component, this.defaultViewContainer, bindings, config);
+                bindings?: ModalConfig | ResolvedReflectiveProvider[],
+                config?: ModalConfig): Promise<ModalDialogInstance> {                    
+        return this.openInside(component, this.defaultViewContainer, bindings as ResolvedReflectiveProvider[], config);
     }
 
     /**
@@ -84,15 +86,20 @@ export class Modal {
      * @param config A Modal Configuration object.
      * @returns {Promise<ModalDialogInstance>}
      */
+    public openInside(component: Type, viewContainer: ViewContainerRef, config?: ModalConfig): Promise<ModalDialogInstance>;
+    public openInside(component: Type, viewContainer: ViewContainerRef, bindings?: ResolvedReflectiveProvider[], config?: ModalConfig): Promise<ModalDialogInstance>;
     public openInside(component: Type,
                       viewContainer: ViewContainerRef,
-                      bindings: ResolvedReflectiveProvider[],
+                      bindings?: ModalConfig | ResolvedReflectiveProvider[],
                       config?: ModalConfig): Promise<ModalDialogInstance> {
-
+        if(!Array.isArray(bindings)){
+            config = bindings as any;
+            bindings = [];
+        }
         config = (config) ? ModalConfig.makeValid(config, this.config) : this.config;
 
         const dialog = new ModalDialogInstance(config);
-        const compileConfig = new ModalCompileConfig(component, bindings || []);
+        const compileConfig = new ModalCompileConfig(component, bindings as ResolvedReflectiveProvider[] || []);
         dialog.inElement = viewContainer !== this.defaultViewContainer;
 
         let dialogBindings = ReflectiveInjector.resolve([

--- a/src/components/angular2-modal/providers/Modal.ts
+++ b/src/components/angular2-modal/providers/Modal.ts
@@ -70,7 +70,7 @@ export class Modal {
      * @param config A Modal Configuration object.
      * @returns {Promise<ModalDialogInstance>}
      */
-    public open(component: FunctionConstructor,
+    public open(component: Type,
                 bindings: ResolvedReflectiveProvider[],
                 config?: ModalConfig): Promise<ModalDialogInstance> {
         return this.openInside(component, this.defaultViewContainer, bindings, config);
@@ -84,7 +84,7 @@ export class Modal {
      * @param config A Modal Configuration object.
      * @returns {Promise<ModalDialogInstance>}
      */
-    public openInside(component: FunctionConstructor,
+    public openInside(component: Type,
                       viewContainer: ViewContainerRef,
                       bindings: ResolvedReflectiveProvider[],
                       config?: ModalConfig): Promise<ModalDialogInstance> {


### PR DESCRIPTION
Just a nitpick.
In `open` and `openInside` changed the type of the argument `component` from `FunctionConstructor` to `Type` to avoid the need to cast an angular component to any.

Eg: [Here](https://github.com/shlomiassaf/angular2-modal/blob/master/src/demo/app/demoPage/demoPage.ts#L68) there would be no need to cast the `AdditionCalculateWindow` to `any`.

Also why not set `bindings` optional? There is already a check in the [code](https://github.com/shlomiassaf/angular2-modal/blob/master/src/components/angular2-modal/providers/Modal.ts#L95).
If you agree I can push a new change to this pr.