### PR TITLE
Removed DialogRef export from angualr2-modal export file

### DIFF
--- a/src/components/angular2-modal/angular2-modal.all.ts
+++ b/src/components/angular2-modal/angular2-modal.all.ts
@@ -5,7 +5,8 @@ import {DOMModalRenderer} from './providers/dom-modal-renderer';
 
 export * from './framework/fluent-assign';
 export * from './models/tokens';
-export * from './models/dialog-ref';
+// Fixes https://github.com/shlomiassaf/angular2-modal/issues/79
+// export * from './models/dialog-ref';
 export * from './models/modal-context';
 export * from './models/modal-open-context';
 export {Modal} from './providers/modal';

--- a/src/components/angular2-modal/angular2-modal.ts
+++ b/src/components/angular2-modal/angular2-modal.ts
@@ -5,7 +5,8 @@ import {DOMModalRenderer} from './providers/dom-modal-renderer';
 
 export * from './framework/fluent-assign';
 export * from './models/tokens';
-export * from './models/dialog-ref';
+// Fixes https://github.com/shlomiassaf/angular2-modal/issues/79
+// export * from './models/dialog-ref';
 export * from './models/modal-context';
 export * from './models/modal-open-context';
 export {Modal} from './providers/modal';

--- a/src/components/angular2-modal/plugins/js-native/presets/js-native-preset.ts
+++ b/src/components/angular2-modal/plugins/js-native/presets/js-native-preset.ts
@@ -1,5 +1,6 @@
 import { ViewContainerRef, ResolvedReflectiveProvider } from '@angular/core';
-import { DialogRef, DROP_IN_TYPE } from '../../../angular2-modal';
+import { DROP_IN_TYPE } from '../../../angular2-modal';
+import { DialogRef } from '../../../models/dialog-ref';
 import { Modal } from '../modal';
 
 import {

--- a/src/demo/app/bootstrap-demo/bootstrap-demo-page/custom-modal-sample.ts
+++ b/src/demo/app/bootstrap-demo/bootstrap-demo-page/custom-modal-sample.ts
@@ -1,6 +1,7 @@
 import {Component} from '@angular/core';
 
-import {DialogRef, ModalComponent} from '../../../../components/angular2-modal';
+import {ModalComponent} from '../../../../components/angular2-modal';
+import {DialogRef} from '../../../../components/angular2-modal/models/dialog-ref';
 import {BSModalContext} from '../../../../components/angular2-modal/plugins/bootstrap/index';
 
 export class AdditionCalculateWindowData extends BSModalContext {

--- a/src/demo/app/demo-head/deam-head.ts
+++ b/src/demo/app/demo-head/deam-head.ts
@@ -8,7 +8,7 @@ import {
     ViewContainerRef
 } from '@angular/core';
 
-import { DialogRef } from '../../../components/angular2-modal';
+import { DialogRef } from '../../../components/angular2-modal/models/dialog-ref';
 
 export interface ModalCommandDescriptor {
     text: string;

--- a/src/demo/app/home/in-app-plugin/modal-backdrop.ts
+++ b/src/demo/app/home/in-app-plugin/modal-backdrop.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 
-import { DialogRef } from '../../../../components/angular2-modal';
+import { DialogRef } from '../../../../components/angular2-modal/models/dialog-ref';
 import { Modal } from './modal';
 import { InAppModalContext } from './modal-context';
 

--- a/src/demo/app/vex-demo/login-dialog.ts
+++ b/src/demo/app/vex-demo/login-dialog.ts
@@ -3,7 +3,8 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
-import {ModalComponent, DialogRef} from '../../../components/angular2-modal';
+import {ModalComponent} from '../../../components/angular2-modal';
+import {DialogRef} from '../../../components/angular2-modal/models/dialog-ref';
 
 import {
     DialogPreset,


### PR DESCRIPTION
Fixes the issue https://github.com/shlomiassaf/angular2-modal/issues/79 by removing the possibility to import `DialogRef` from `'angular2-modal'`.

I admit it's not the most elegant solution.
