### PR TITLE
Added "okBtn" and "cancelBtn" caption configuration for VEX

### DIFF
--- a/src/components/angular2-modal/plugins/vex/presets/dropin-preset.ts
+++ b/src/components/angular2-modal/plugins/vex/presets/dropin-preset.ts
@@ -8,6 +8,8 @@ import { DialogPreset, DialogPresetBuilder } from './dialog-preset';
 import { extend } from '../../../framework/utils';
 
 const DEFAULT_SETTERS = [
+    'okBtn',
+    'cancelBtn',
     'placeholder',
     'showCloseButton'
 ];
@@ -23,6 +25,16 @@ export class DropInPreset extends DialogPreset {
     message: string;
 
     /**
+     * The default Ok button caption.
+     */
+    okBtn: string = 'Yep';
+
+    /**
+     * The default Cancel button caption.
+     */
+    cancelBtn: string = 'Nope';
+
+    /**
      * A placeholder for the input element.
      * Valid only for prompt modal.
      */
@@ -33,7 +45,7 @@ export class DropInPreset extends DialogPreset {
     get showInput(): boolean {
         return this.dropInType === DROP_IN_TYPE.prompt;
     }
-} 
+}
 
 /**
  * A Preset representing all 3 drop ins (alert, prompt, confirm)
@@ -46,11 +58,21 @@ export class DropInPresetBuilder extends DialogPresetBuilder<DropInPreset> {
     message: FluentAssignMethod<string, this>;
 
     /**
+     * The default Ok button caption.
+     */
+    okBtn: FluentAssignMethod<string, this>;
+
+    /**
+     * The default Cancel button caption.
+     */
+    cancelBtn: FluentAssignMethod<string, this>;
+
+    /**
      * A placeholder for the input element.
      * Valid only for prompt modal.
      */
     placeholder: FluentAssignMethod<string, this>;
-    
+
     constructor(modal: Modal, dropInType: DROP_IN_TYPE, defaultValues: DropInPreset = undefined) {
         super(
             modal,
@@ -61,13 +83,13 @@ export class DropInPresetBuilder extends DialogPresetBuilder<DropInPreset> {
     }
 
     $$beforeOpen(config: DropInPreset): ResolvedReflectiveProvider[] {
-        this.addOkButton('Yep');
+        this.addOkButton(config.okBtn);
 
         switch (config.dropInType) {
             case DROP_IN_TYPE.prompt:
                 config.defaultResult = undefined;
             case DROP_IN_TYPE.confirm:
-                this.addCancelButton('Nope');
+                this.addCancelButton(config.cancelBtn);
                 break;
         }
         return super.$$beforeOpen(config);

--- a/src/demo/app/vex-demo/presets.ts
+++ b/src/demo/app/vex-demo/presets.ts
@@ -17,7 +17,9 @@ export function prompt(modal: Modal): DropInPresetBuilder {
 export function confirm(modal: Modal): DropInPresetBuilder {
     return modal.confirm()
         .className(this.theme)
-        .message('Yes or No?');
+        .message('Yes or No?')
+        .okBtn('Yes')
+        .cancelBtn('No');
 }
 
 export function cascading(modal: Modal): DropInPresetBuilder {


### PR DESCRIPTION
Bootstrap plugin allows the configuration of the default OK/Cancel button captions, but there is no equivalent for VEX. In order to customize the "Yep"/"Nope" captions, you have to create a new DialogPresetBuilder, which seems excessive just to change button text.

I've added two simple properties to change the button text as well as modified the "confirm" demo to show it off.