### PR TITLE
Added event.stopPropagation to the confirm/alert onclick

### DIFF
--- a/src/components/angular2-modal/plugins/bootstrap/modal-footer.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/modal-footer.ts
@@ -39,7 +39,7 @@ export class BSModalFooter {
     constructor() {}
 
     onClick(btn: any, $event: MouseEvent) {
-        event.stopPropagation();
+        $event.stopPropagation();
         this.onButtonClick.emit({btn, $event});
     }
 }

--- a/src/components/angular2-modal/plugins/bootstrap/modal-footer.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/modal-footer.ts
@@ -39,6 +39,7 @@ export class BSModalFooter {
     constructor() {}
 
     onClick(btn: any, $event: MouseEvent) {
+        event.stopPropagation();
         this.onButtonClick.emit({btn, $event});
     }
 }

--- a/src/components/angular2-modal/plugins/vex/dialog-form-modal.ts
+++ b/src/components/angular2-modal/plugins/vex/dialog-form-modal.ts
@@ -62,7 +62,7 @@ export class VEXDialogButtons {
     @Output() public onButtonClick = new EventEmitter<VEXButtonClickEvent>();
 
     onClick(btn: any, $event: MouseEvent) {
-        event.stopPropagation();
+        $event.stopPropagation();
         this.onButtonClick.emit({btn, $event});
     }
 }

--- a/src/components/angular2-modal/plugins/vex/dialog-form-modal.ts
+++ b/src/components/angular2-modal/plugins/vex/dialog-form-modal.ts
@@ -62,6 +62,7 @@ export class VEXDialogButtons {
     @Output() public onButtonClick = new EventEmitter<VEXButtonClickEvent>();
 
     onClick(btn: any, $event: MouseEvent) {
+        event.stopPropagation();
         this.onButtonClick.emit({btn, $event});
     }
 }


### PR DESCRIPTION
When opened on a dialog the default confirm/alert cause its closure because of https://github.com/shlomiassaf/angular2-modal/issues/111

This avoids the issue.
