### PR TITLE
Fix typings import paths

### DIFF
--- a/src/components/angular2-modal/plugins/bootstrap/bootstrap.module.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/bootstrap.module.ts
@@ -15,7 +15,7 @@ import {
   Modal as BaseModal,
   ModalBackdropComponent,
   ModalDropInFactory
-} from '../../../../components/angular2-modal';
+} from '../../../angular2-modal';
 
 function getProviders(): any[] {
   return [

--- a/src/components/angular2-modal/plugins/bootstrap/index.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/index.ts
@@ -9,7 +9,7 @@ export {
     MessageModalPresetBuilder
 } from './presets/message-modal-preset';
 
-export { ModalOpenContext, ModalOpenContextBuilder } from '../../../../components/angular2-modal';
+export { ModalOpenContext, ModalOpenContextBuilder } from '../../../angular2-modal';
 export { OneButtonPreset, OneButtonPresetBuilder } from './presets/one-button-preset';
 export { TwoButtonPreset, TwoButtonPresetBuilder } from './presets/two-button-preset';
 export { BSModal, Modal } from './modal';

--- a/src/components/angular2-modal/plugins/bootstrap/message-modal.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/message-modal.ts
@@ -1,6 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 
-import { DialogRef, ModalComponent } from '../../../../components/angular2-modal';
+import { DialogRef, ModalComponent } from '../../../angular2-modal';
 import { BSModalFooter, FooterButtonClickEvent } from './modal-footer';
 import { MessageModalPreset } from'./presets/message-modal-preset';
 

--- a/src/components/angular2-modal/plugins/bootstrap/modal-backdrop.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/modal-backdrop.ts
@@ -10,7 +10,7 @@ import {
   transition
 } from '@angular/core';
 
-import { DialogRef } from '../../../../components/angular2-modal';
+import { DialogRef } from '../../../angular2-modal';
 import { BSModalContext } from './modal-context';
 
 let dialogRefCount = 0;

--- a/src/components/angular2-modal/plugins/bootstrap/modal-container.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/modal-container.ts
@@ -19,7 +19,7 @@ import {
   DialogRef,
   ModalCompileConfig,
   supportsKey
-} from '../../../../components/angular2-modal';
+} from '../../../angular2-modal';
 
 import { Modal } from './modal';
 import { BSModalContext } from './modal-context';

--- a/src/components/angular2-modal/plugins/bootstrap/modal-context.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/modal-context.ts
@@ -4,7 +4,7 @@ import {
   FluentAssignMethod,
   extend,
   arrayUnion
-} from '../../../../components/angular2-modal';
+} from '../../../angular2-modal';
 
 const DEFAULT_VALUES = {
   dialogClass: 'modal-dialog',

--- a/src/components/angular2-modal/plugins/bootstrap/modal.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/modal.ts
@@ -1,4 +1,4 @@
-import {Modal as BaseModal} from '../../../../components/angular2-modal';
+import {Modal as BaseModal} from '../../../angular2-modal';
 import {OneButtonPresetBuilder} from './../bootstrap/presets/one-button-preset';
 import {TwoButtonPresetBuilder} from './../bootstrap/presets/two-button-preset';
 

--- a/src/components/angular2-modal/plugins/bootstrap/presets/message-modal-preset.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/presets/message-modal-preset.ts
@@ -4,7 +4,7 @@ import {
   setAssignAlias,
   extend,
   arrayUnion
-} from '../../../../../components/angular2-modal';
+} from '../../../../angular2-modal';
 import { BSMessageModalButtonConfig, BSMessageModalButtonHandler } from '../message-modal';
 import { BSModalContext, BSModalContextBuilder }  from '../modal-context';
 import { BSMessageModal } from '../message-modal';

--- a/src/components/angular2-modal/plugins/bootstrap/presets/one-button-preset.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/presets/one-button-preset.ts
@@ -1,5 +1,5 @@
 import { ResolvedReflectiveProvider } from '@angular/core';
-import { Modal, FluentAssignMethod, extend } from '../../../../../components/angular2-modal';
+import { Modal, FluentAssignMethod, extend } from '../../../../angular2-modal';
 import { BSMessageModal } from '../message-modal';
 import { MessageModalPresetBuilder, MessageModalPreset } from './message-modal-preset';
 

--- a/src/components/angular2-modal/plugins/bootstrap/presets/two-button-preset.ts
+++ b/src/components/angular2-modal/plugins/bootstrap/presets/two-button-preset.ts
@@ -2,8 +2,8 @@ import { ResolvedReflectiveProvider } from '@angular/core';
 import {
   FluentAssignMethod,
     extend
-} from '../../../../../components/angular2-modal';
-import { Modal } from '../../../../../components/angular2-modal';
+} from '../../../../angular2-modal';
+import { Modal } from '../../../../angular2-modal';
 import { BSMessageModal } from '../message-modal';
 import { MessageModalPresetBuilder } from './message-modal-preset';
 import { OneButtonPreset } from './one-button-preset';


### PR DESCRIPTION
The `.d.ts` files were referencing files that didn't exist.  I removed unnecessary `../components/` from import statements in the bootstrap plugin.  Other plugins might have the same issue, but I didn't check them.