### PR TITLE
ng2 package dependencies version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,15 +36,15 @@
     "start": "npm run server:dev"
   },
   "dependencies": {
-    "@angular/common": "2.0.0-rc.6",
-    "@angular/compiler": "2.0.0-rc.6",
-    "@angular/core": "2.0.0-rc.6",
-    "@angular/forms": "2.0.0-rc.6",
-    "@angular/platform-browser": "2.0.0-rc.6",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.6",
-    "@angular/router": "3.0.0-rc.2",
-    "rxjs": "5.0.0-beta.11",
-    "zone.js": "^0.6.17"
+    "@angular/common": "2.0.0",
+    "@angular/compiler": "2.0.0",
+    "@angular/core": "2.0.0",
+    "@angular/forms": "2.0.0",
+    "@angular/platform-browser": "2.0.0",
+    "@angular/platform-browser-dynamic": "2.0.0",
+    "@angular/router": "3.0.0",
+    "rxjs": "5.0.0-beta.12",
+    "zone.js": "^0.6.21"
   },
   "devDependencies": {
     "@types/core-js": "^0.9.28",


### PR DESCRIPTION
updated ng2 package dependencies to final ng2 versions, rxjs to version 5.0.0.beta12 and zonejs to version 0.6.21