### PR TITLE
Fixing missing rxjs operator import 'combineLatest' in vex

### DIFF
--- a/src/components/angular2-modal/plugins/vex/modal.ts
+++ b/src/components/angular2-modal/plugins/vex/modal.ts
@@ -1,5 +1,6 @@
 import { Observable } from "rxjs";
 import 'rxjs/add/operator/first';
+import 'rxjs/add/operator/combineLatest';
 
 import { Injectable, ResolvedReflectiveProvider as RRP } from '@angular/core';
 


### PR DESCRIPTION
The demo site works and masked the problem because `combineLatest` is imported for bootstrap plugin. But when only use vex plugin the problem pop up.

Without this fix, it'll cause https://github.com/shlomiassaf/angular2-modal/blob/master/src/components/angular2-modal/models/dialog-ref.ts#L64 to be called twice and produce error like following when closing the modal:

```
EXCEPTION: Uncaught (in promise): undefinedErrorHandler.handleError 
ORIGINAL STACKTRACE:ErrorHandler.handleError
Error: Uncaught (in promise): undefined
    at resolvePromise (http://localhost:3000/polyfills.bundle.js:21315:32)
    at PromiseCompleter.reject (http://localhost:3000/polyfills.bundle.js:21292:14)
    at http://localhost:3000/vendor.bundle.js:13331:32
    at ZoneDelegate.invokeTask (http://localhost:3000/polyfills.bundle.js:21122:38)
    at Object.onInvokeTask (http://localhost:3000/vendor.bundle.js:6164:42)
    at ZoneDelegate.invokeTask (http://localhost:3000/polyfills.bundle.js:21121:43)
    at Zone.runTask (http://localhost:3000/polyfills.bundle.js:21022:48)
    at ZoneTask.invoke (http://localhost:3000/polyfills.bundle.js:21190:34)
  -------------   Elapsed: 1003 ms; At: Tue Oct 11 2016 14:00:09 GMT-0500 (CDT)   -------------  
    at Object.onScheduleTask (http://localhost:3000/polyfills.bundle.js:20811:19)
    at ZoneDelegate.scheduleTask (http://localhost:3000/polyfills.bundle.js:21099:50)
    at Zone.scheduleMacroTask (http://localhost:3000/polyfills.bundle.js:21039:40)
    at http://localhost:3000/polyfills.bundle.js:22081:30
    at setTimeout (eval at createNamedFn (http://localhost:3000/polyfills.bundle.js:21761:18), <anonymous>:3:37)
    at ModalOverlay.canDestroy (http://localhost:3000/vendor.bundle.js:13329:29)
    at DialogRef.destroy (http://localhost:3000/vendor.bundle.js:12700:47)
    at _close (http://localhost:3000/vendor.bundle.js:12658:24)
    at http://localhost:3000/vendor.bundle.js:12662:43
    at ZoneDelegate.invoke (http://localhost:3000/polyfills.bundle.js:21089:29)
    at Object.onInvoke (http://localhost:3000/vendor.bundle.js:6173:42)
    at ZoneDelegate.invoke (http://localhost:3000/polyfills.bundle.js:21088:35)
    at Zone.run (http://localhost:3000/polyfills.bundle.js:20982:44)
    at http://localhost:3000/polyfills.bundle.js:21348:58
    at ZoneDelegate.invokeTask (http://localhost:3000/polyfills.bundle.js:21122:38)
    at Object.onInvokeTask (http://localhost:3000/vendor.bundle.js:6164:42)
    at ZoneDelegate.invokeTask (http://localhost:3000/polyfills.bundle.js:21121:43)
    at Zone.runTask (http://localhost:3000/polyfills.bundle.js:21022:48)
    at drainMicroTaskQueue (http://localhost:3000/polyfills.bundle.js:21254:36)
    at HTMLButtonElement.ZoneTask.invoke (http://localhost:3000/polyfills.bundle.js:21194:26)
  -------------   Elapsed: 1 ms; At: Tue Oct 11 2016 14:00:09 GMT-0500 (CDT)   -------------  
    at Object.onScheduleTask (http://localhost:3000/polyfills.bundle.js:20811:19)
    at ZoneDelegate.scheduleTask (http://localhost:3000/polyfills.bundle.js:21099:50)
    at Zone.scheduleMicroTask (http://localhost:3000/polyfills.bundle.js:21036:40)
    at scheduleResolveOrReject (http://localhost:3000/polyfills.bundle.js:21346:15)
    at ZoneAwarePromise.then (http://localhost:3000/polyfills.bundle.js:21422:18)
    at DialogRef.close (http://localhost:3000/vendor.bundle.js:12661:44)
    at Object.onClick (http://localhost:3000/vendor.bundle.js:29842:32)
    at DialogFormModal.exports.DialogFormModal.DialogFormModal.onButtonClick (http://localhost:3000/vendor.bundle.js:28730:21)
    at DebugAppView._View_DialogFormModal0._handle_onButtonClick_4_0 (DialogFormModal.ngfactory.js:96:28)
    at http://localhost:3000/vendor.bundle.js:9617:29
    at SafeSubscriber.schedulerFn [as _next] (http://localhost:3000/vendor.bundle.js:6116:59)
    at SafeSubscriber.__tryOrUnsub (http://localhost:3000/vendor.bundle.js:10228:17)
    at SafeSubscriber.next (http://localhost:3000/vendor.bundle.js:10177:23)
    at Subscriber._next (http://localhost:3000/vendor.bundle.js:10130:27)
    at Subscriber.next (http://localhost:3000/vendor.bundle.js:10094:19)
    at EventEmitter.Subject.next (http://localhost:3000/vendor.bundle.js:16789:26)
    at EventEmitter.emit (http://localhost:3000/vendor.bundle.js:6095:81)
    at VEXDialogButtons.exports.VEXDialogButtons.VEXDialogButtons.onClick (http://localhost:3000/vendor.bundle.js:28705:29)
    at DebugAppView._View_VEXDialogButtons1._handle_click_0_0 (VEXDialogButtons.ngfactory.js:128:35)
    at http://localhost:3000/vendor.bundle.js:9617:29
    at http://localhost:3000/vendor.bundle.js:15544:41
    at http://localhost:3000/vendor.bundle.js:15657:116
    at ZoneDelegate.invoke (http://localhost:3000/polyfills.bundle.js:21089:29)
    at Object.onInvoke (http://localhost:3000/vendor.bundle.js:6173:42)
    at ZoneDelegate.invoke (http://localhost:3000/polyfills.bundle.js:21088:35)
    at Zone.runGuarded (http://localhost:3000/polyfills.bundle.js:20996:48)
    at NgZoneImpl.runInnerGuarded (http://localhost:3000/vendor.bundle.js:6202:83)
    at NgZone.runGuarded (http://localhost:3000/vendor.bundle.js:6434:78)
    at HTMLButtonElement.outsideHandler (http://localhost:3000/vendor.bundle.js:15657:84)
    at ZoneDelegate.invokeTask (http://localhost:3000/polyfills.bundle.js:21122:38)
    at Zone.runTask (http://localhost:3000/polyfills.bundle.js:21022:48)
    at HTMLButtonElement.ZoneTask.invoke (http://localhost:3000/polyfills.bundle.js:21190:34)
```
