### PR TITLE
doc: remove the `ViewEncapsulation` import (quick walkthrough)

### DIFF
--- a/QUICKTHROUGH.md
+++ b/QUICKTHROUGH.md
@@ -7,7 +7,7 @@
 
 #### Configure root element
 ```ts
-import { Component, ViewContainerRef, ViewEncapsulation } from '@angular/core';
+import { Component, ViewContainerRef } from '@angular/core';
 import { Overlay } from 'angular2-modal';
 import { Modal } from 'angular2-modal/plugins/bootstrap';
 


### PR DESCRIPTION
It is not used by the example code