### PR TITLE
Graceful handling of missing document keyword

### DIFF
--- a/src/lib/providers/outside-event-plugin.ts
+++ b/src/lib/providers/outside-event-plugin.ts
@@ -38,7 +38,7 @@ export class DOMOutsideEventPlugin { // extends EventManagerPlugin
 
     constructor() {
         // TODO: use DI factory for this.
-        if (!document || typeof document.addEventListener !== 'function') {
+        if (typeof document === 'undefined' || !document || typeof document.addEventListener !== 'function') {
             this.addEventListener = noop as any;
         }
     }


### PR DESCRIPTION
Added to support angular universal. Same problem originally solved by https://github.com/shlomiassaf/angular2-modal/pull/144, but updated to reflect recent changes.