### PR TITLE
refactor: <template> element is deprecated. use <ng-template> instead

### DIFF
--- a/src/lib/overlay/overlay.component.ts
+++ b/src/lib/overlay/overlay.component.ts
@@ -35,10 +35,10 @@ export interface EmbedComponentConfig {
   },
   encapsulation: ViewEncapsulation.None,
   template:
-`<template #innerView></template>
-<template #template let-ctx>
-    <template [swapCmp]="ctx.component" [swapCmpBindings]="ctx.bindings" [swapCmpProjectables]="ctx.projectableNodes"></template>
-</template>
+`<ng-template #innerView></ng-template>
+<ng-template #template let-ctx>
+    <ng-template [swapCmp]="ctx.component" [swapCmpBindings]="ctx.bindings" [swapCmpProjectables]="ctx.projectableNodes"></ng-template>
+</ng-template>
 `
 })
 export class ModalOverlay extends BaseDynamicComponent {
@@ -103,7 +103,7 @@ export class ModalOverlay extends BaseDynamicComponent {
     };
     Object.keys(style).forEach( k => this.setStyle(k, style[k]) );
   }
-  
+
   insideElement(): void {
     const style = {
       position: 'absolute',
@@ -204,7 +204,7 @@ export class ModalOverlay extends BaseDynamicComponent {
    * A handler running before destruction of the overlay
    * use to delay destruction due to animation.
    * This is part of the workaround for animation, see canDestroy.
-   * 
+   *
    * NOTE: There is no guarantee that the listeners will fire, use dialog.onDestory for that.
    * @param fn
    */
@@ -214,7 +214,7 @@ export class ModalOverlay extends BaseDynamicComponent {
     }
     this.beforeDestroyHandlers.push(fn);
   }
-  
+
   documentKeypress(event: KeyboardEvent) {
     // check that this modal is the last in the stack.
     if (!this.dialogRef.overlay.isTopMost(this.dialogRef)) return;

--- a/src/lib/plugins/vex/dialog-form-modal.ts
+++ b/src/lib/plugins/vex/dialog-form-modal.ts
@@ -39,7 +39,7 @@ export interface VEXButtonClickEvent {
   selector: 'vex-dialog-buttons',
   encapsulation: ViewEncapsulation.None,
   template: `<div class="vex-dialog-buttons">
-    <button type="button" 
+    <button type="button"
          *ngFor="let btn of buttons;"
          [class]="btn.cssClass"
          (click)="onClick(btn, $event)">{{btn.caption}}</button>
@@ -72,7 +72,7 @@ export class VEXDialogButtons {
   selector: 'modal-dialog',
   encapsulation: ViewEncapsulation.None,
   template: `<form class="vex-dialog-form">
-    <template [swapCmp]="context.content"></template>
+    <ng-template [swapCmp]="context.content"></ng-template>
     <vex-dialog-buttons [buttons]="context.buttons"
                         (onButtonClick)="onButtonClick($event)"></vex-dialog-buttons>
 </form>`
@@ -97,13 +97,13 @@ export class DialogFormModal implements ModalComponent<DialogPreset> {
  <div *ngIf="context.showInput" class="vex-dialog-input">
    <input #input
           autofocus
-          name="vex" 
-          type="text" 
+          name="vex"
+          type="text"
           class="vex-dialog-prompt-input"
-           (change)="context.defaultResult = input.value" 
+           (change)="context.defaultResult = input.value"
           placeholder="{{context.placeholder}}">
  </div>
- <div *ngIf="context.showCloseButton" 
+ <div *ngIf="context.showCloseButton"
       [class]="context.closeClassName"
       (click)="dialog.dismiss()"></div>`
 })


### PR DESCRIPTION
Starting from angular v4.0.0-rc.0 `<template>` element is deprecated.