### PR TITLE
Fixed install warning when using with angular 4

### DIFF
--- a/package.release.json
+++ b/package.release.json
@@ -5,8 +5,8 @@
   "scripts": {},
   "dependencies": {},
   "peerDependencies": {
-    "@angular/core": "^2.1.1",
-    "@angular/common": "^2.1.1"
+    "@angular/core": "^2.1.1 || ^4.0.0",
+    "@angular/common": "^2.1.1 || ^4.0.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
During install in an angular 4 project warnings are thrown due to semantic versioning. As the package is angular-4 compatible there was an easy way to prevent this.

```
warning "angular2-modal@2.0.3" has incorrect peer dependency "@angular/core@^2.1.1".
warning "angular2-modal@2.0.3" has incorrect peer dependency "@angular/common@^2.1.1".
```