### PR TITLE
Add generic type for ModuleWithProviders

### DIFF
--- a/projects/ngx-modialog/src/lib/ngx-modialog.module.ts
+++ b/projects/ngx-modialog/src/lib/ngx-modialog.module.ts
@@ -44,7 +44,7 @@ export class ModalModule {
    * using entryComponents, this is an easy way to do it.
    * @param entryComponents A list of dynamically inserted components (dialog's).
    */
-  static withComponents(entryComponents: Array<Type<any> | any[]>): ModuleWithProviders {
+  static withComponents(entryComponents: Array<Type<any> | any[]>): ModuleWithProviders<ModalModule> {
     return {
       ngModule: ModalModule,
       providers: [
@@ -57,7 +57,7 @@ export class ModalModule {
    * Returns a NgModule for use in the root Module.
    * @param entryComponents A list of dynamically inserted components (dialog's).
    */
-  static forRoot(entryComponents?: Array<Type<any> | any[]>): ModuleWithProviders {
+  static forRoot(entryComponents?: Array<Type<any> | any[]>): ModuleWithProviders<ModalModule> {
     return {
       ngModule: ModalModule,
       providers: [


### PR DESCRIPTION
As per angular changes. Angular version 9 deprecates the use of ModuleWithProviders without an explicitly generic type
https://angular.io/guide/migration-module-with-providers